### PR TITLE
feat: Password generation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,8 @@
         "bradlc.vscode-tailwindcss",
         "Nuxtr.nuxt-vscode-extentions",
         "qwtel.sqlite-viewer",
-        "Gruntfuggly.todo-tree"
+        "Gruntfuggly.todo-tree",
+        "vitest.explorer"
       ]
     },
     "settings": {

--- a/components/CreateEntry.vue
+++ b/components/CreateEntry.vue
@@ -25,6 +25,7 @@ async function createEntry() {
     <PasswordInput
       v-model="password"
       :disabled="false"
+      :can-be-generated="true"
       placeholder="Enter your password"
       :ui="{ trailing: 'flex gap-1 pe-1 items-center' }"
       class="w-full"

--- a/components/PasswordInput.vue
+++ b/components/PasswordInput.vue
@@ -3,9 +3,11 @@ const props = withDefaults(defineProps<{
   modelValue: string
   disabled?: boolean
   copyButton?: boolean
+  canBeGenerated?: boolean
 }>(), {
   disabled: false,
   copyButton: true,
+  canBeGenerated: false,
 })
 
 const emit = defineEmits<{
@@ -76,6 +78,7 @@ async function generateRandomPassword() {
       @click="copyToClipboard"
     />
     <UButton
+      v-if="canBeGenerated"
       color="neutral"
       variant="link"
       size="sm"

--- a/components/PasswordInput.vue
+++ b/components/PasswordInput.vue
@@ -34,6 +34,11 @@ function copyToClipboard() {
     description: 'The password has been copied in the clipboard',
   })
 }
+
+async function generateRandomPassword() {
+  const result = await $fetch('/api/passwords/generate')
+  inputValue.value = result
+}
 </script>
 
 <template>
@@ -69,6 +74,13 @@ function copyToClipboard() {
       size="sm"
       :icon="copied ? 'i-lucide-copy-check' : 'i-lucide-copy'"
       @click="copyToClipboard"
+    />
+    <UButton
+      color="neutral"
+      variant="link"
+      size="sm"
+      icon="mdi:dice"
+      @click="generateRandomPassword"
     />
   </div>
 </template>

--- a/components/Setup/AdminAccount.vue
+++ b/components/Setup/AdminAccount.vue
@@ -100,7 +100,7 @@ async function createAdminAccount() {
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <UFormField label="Password" name="password">
-          <PasswordInput v-model="state.password" :copy-button="false" />
+          <PasswordInput v-model="state.password" :copy-button="false" :can-be-generated="true" />
         </UFormField>
 
         <UFormField label="Password confirmation" name="passwordConfirmation">

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "better-auth": "^1.2.6",
         "better-sqlite3": "^11.9.1",
         "drizzle-orm": "^0.43.1",
+        "generate-password": "^1.7.1",
         "lint-staged": "^15.5.1",
         "nuxt": "^3.17.2",
         "shamir-secret-sharing": "^0.0.4",
@@ -11004,6 +11005,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/generate-password": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/generate-password/-/generate-password-1.7.1.tgz",
+      "integrity": "sha512-9bVYY+16m7W7GczRBDqXE+VVuCX+bWNrfYKC/2p2JkZukFb2sKxT6E3zZ3mJGz7GMe5iRK0A/WawSL3jQfJuNQ==",
+      "license": "MIT"
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "better-auth": "^1.2.6",
     "better-sqlite3": "^11.9.1",
     "drizzle-orm": "^0.43.1",
+    "generate-password": "^1.7.1",
     "lint-staged": "^15.5.1",
     "nuxt": "^3.17.2",
     "shamir-secret-sharing": "^0.0.4",

--- a/server/api/passwords/generate.get.ts
+++ b/server/api/passwords/generate.get.ts
@@ -1,0 +1,13 @@
+import { generate } from 'generate-password'
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const passwordSize = parseInt(query.size as string) || 20
+  return generate({
+    length: passwordSize,
+    numbers: true,
+    symbols: true,
+    uppercase: true,
+    lowercase: true,
+  })
+})

--- a/tests/api/passwords.test.ts
+++ b/tests/api/passwords.test.ts
@@ -1,0 +1,27 @@
+import { $fetch, setup } from '@nuxt/test-utils'
+import { describe, expect, it } from 'vitest'
+
+describe('calling passwords api', async () => {
+  await setup()
+
+  it('returns a generated password when calling generating', async () => {
+    const result = await $fetch('/api/passwords/generate')
+
+    expect(typeof result).toBe('string')
+    expect(result.length).not.toBe(0)
+  })
+
+  it('returns a password of length 20 when calling default generating', async () => {
+    const result = await $fetch('/api/passwords/generate')
+
+    expect(result.length).toBe(20)
+  })
+
+  it.each([
+    5, 20, 50,
+  ])('returns a password of given length when calling generating with length', async (size) => {
+    const result = await $fetch('/api/passwords/generate', { params: { size } })
+
+    expect(result.length).toBe(size)
+  })
+})

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,12 +1,8 @@
-import { fileURLToPath } from 'node:url'
 import { $fetch, isDev, setup } from '@nuxt/test-utils'
 import { describe, expect, it } from 'vitest'
 
 describe('frontend', async () => {
-  await setup({
-    rootDir: fileURLToPath(new URL('..', import.meta.url)),
-    server: true,
-  })
+  await setup()
 
   it('renders Setup word on /setup page', async () => {
     expect(await $fetch('/setup')).toMatch('Setup')

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,7 @@
 import { defineVitestConfig } from '@nuxt/test-utils/config'
 
 export default defineVitestConfig({
-  // any custom Vitest config you require
+  test: {
+    environment: 'nuxt',
+  },
 })


### PR DESCRIPTION
# Pull Request Title

## Description
Add an api endpoint to generate a password instead of letting the user choosing it

## Changes Made
- New endpoint
- New button next to the password input in front
- Tests of the endpoint

## Checklist
- [ X] I have tested the changes locally.
- [ ] I have updated the documentation (if applicable).
- [ X] I have added tests that prove my fix is effective or that my feature works.
- [ X] I have ensured that my code follows the project's coding standards.

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/65874252-af96-4e76-ac5f-1cb15a48f771)
