### PR TITLE
feat: add CD pipeline trigger after successful CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,3 +69,21 @@ jobs:
       - name: Run Unit Tests
         working-directory: server/
         run: uv run pytest -n auto
+
+  trigger-cd:
+    name: Trigger CD Pipeline
+    runs-on: ubuntu-latest
+    needs: [front-ci, back-ci]
+    if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Trigger deployment workflow
+        run: |
+          echo "🚀 Triggering CD pipeline for deployment..."
+          curl -L -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.CD_TRIGGER_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/soma-smart/le-coffre-deployment/dispatches \
+            -d '{"event_type":"ci-success","client_payload":{"source_ref":"${{ github.sha }}","branch":"${{ github.ref_name }}","commit_message":"${{ github.event.head_commit.message }}","author":"${{ github.event.head_commit.author.name }}"}}'
+          echo "✅ CD pipeline triggered successfully"


### PR DESCRIPTION
## Summary

This PR adds automatic triggering of the CD (Continuous Deployment) pipeline in the `le-coffre-deployment` repository after successful CI builds on the main branch.

## Changes

- Added a new `trigger-cd` job that:
  - Depends on both `front-ci` and `back-ci` jobs
  - Only runs on successful CI completion
  - Only triggers on pushes to `main` branch (not on PRs)
  - Sends a `repository_dispatch` event to trigger the deployment workflow

## Why this change?

Previously, the deployment workflow ran on a daily schedule (2am UTC), which meant:
- Deployments happened even without code changes
- New features had to wait up to 24h to be deployed
- Failed deployments weren't linked to specific CI runs

With this change:
- ✅ Deployment only happens after successful tests
- ✅ Automatic deployment immediately after merging to main
- ✅ Clear traceability between CI and CD

## Prerequisites

Before merging, you need to:

1. **Create a Personal Access Token (PAT)** with `repo` scope
2. **Add it as a secret** in this repository:
   - Go to Settings → Secrets and variables → Actions
   - Create secret: `CD_TRIGGER_TOKEN`
   - Value: your PAT

## Test Plan

- [ ] Verify the workflow syntax is valid
- [ ] Ensure `CD_TRIGGER_TOKEN` secret is configured
- [ ] Merge and verify the trigger-cd job runs successfully
- [ ] Confirm the deployment workflow in `le-coffre-deployment` is triggered

---

🤖 Part of the CI/CD pipeline improvement initiative