### PR TITLE
fix: configure logging to stdout for Kubernetes pod visibility

### DIFF
--- a/server/src/main.py
+++ b/server/src/main.py
@@ -1,4 +1,6 @@
 import os
+import sys
+import logging
 from pathlib import Path
 from fastapi import FastAPI
 from contextlib import asynccontextmanager
@@ -6,6 +8,20 @@ from sqlmodel import Session, create_engine
 from sqlalchemy.orm import sessionmaker
 from alembic.config import Config
 from alembic import command
+
+# Configure logging to stdout for Kubernetes
+# Force configuration even if handlers already exist (e.g., from uvicorn)
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(sys.stdout)
+    ],
+    force=True  # Override any existing configuration
+)
+
+# Ensure all loggers propagate to root logger
+logging.getLogger().setLevel(logging.INFO)
 
 from audit_logging_context.adapters.primary.all_events_subscriber import (
     AllEventsSubscriber,


### PR DESCRIPTION
## Summary
- Configure Python logging to output to stdout for Kubernetes pod visibility
- Force logging configuration to override uvicorn defaults
- Ensure all application logs (logging.error calls in routes) are visible in kubectl logs

## Problem
FastAPI application logs were not appearing in kubectl logs output. Only supervisor and uvicorn logs were visible, making debugging difficult.

## Solution
- Added logging.basicConfig() with force=True to override uvicorn's default configuration
- Configured StreamHandler to write to stdout
- Set root logger level to INFO to ensure all loggers propagate correctly
- Added structured log format with timestamp, logger name, level, and message

## Test plan
- [ ] Deploy to Kubernetes cluster
- [ ] Trigger an application error (e.g., invalid login attempt)
- [ ] Verify logs appear in kubectl logs with proper formatting
- [ ] Confirm both uvicorn and application logs are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)