### PR TITLE
fix: logging not visible in Kubernetes (basicConfig force override)

### DIFF
--- a/server/src/main.py
+++ b/server/src/main.py
@@ -14,6 +14,7 @@ from alembic import command
 
 def configure_logging():
     logging.basicConfig(
+        force=True,  # override uvicorn's pre-configured handlers
         level=logging.INFO,
         format="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",


### PR DESCRIPTION
## Summary

- `logging.basicConfig()` is a no-op when handlers are already registered on the root logger
- Uvicorn configures the root logger **before** the FastAPI app starts, so our custom format and log level were silently ignored in production
- Fix: add `force=True` to `basicConfig()` to remove existing handlers before applying our configuration

## Root cause

```
uvicorn starts → configures root logger → app lifespan starts → configure_logging() called → basicConfig() is a no-op (handlers already exist)
```

## Fix

```python
logging.basicConfig(
    force=True,  # override uvicorn's pre-configured handlers
    level=logging.INFO,
    format="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
    datefmt="%Y-%m-%d %H:%M:%S",
)
```

## Checklist
- [x] I have tested the changes locally.
- [x] I have ensured that my code follows the project's coding standards.