### PR TITLE
feat: comprehensive logging and IAM/vault event storage

### DIFF
--- a/server/alembic/env.py
+++ b/server/alembic/env.py
@@ -22,6 +22,8 @@ from password_management_context.adapters.secondary.sql import (
     PasswordEventTable,
 )
 from vault_management_context.adapters.secondary.sql import VaultTable
+from vault_management_context.adapters.secondary.sql.models.vault_event import VaultEventTable
+from identity_access_management_context.adapters.secondary.sql.model.iam_event import IamEventTable
 
 
 from config import get_database_url
@@ -39,6 +41,8 @@ _ = (
     PasswordTable,
     PasswordEventTable,
     VaultTable,
+    VaultEventTable,
+    IamEventTable,
 )
 
 # this is the Alembic Config object, which provides

--- a/server/alembic/versions/c3f8a912b047_add_iam_and_vault_events_tables.py
+++ b/server/alembic/versions/c3f8a912b047_add_iam_and_vault_events_tables.py
@@ -1,0 +1,59 @@
+"""Add IAM and Vault Events Tables
+
+Revision ID: c3f8a912b047
+Revises: aa385458b504
+Create Date: 2026-02-12 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3f8a912b047'
+down_revision: Union[str, Sequence[str], None] = 'aa385458b504'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('iam_events',
+    sa.Column('event_id', sa.Uuid(), nullable=False),
+    sa.Column('event_type', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+    sa.Column('occurred_on', sa.DateTime(), nullable=False),
+    sa.Column('actor_user_id', sa.Uuid(), nullable=True),
+    sa.Column('event_data', sa.JSON(), nullable=True),
+    sa.PrimaryKeyConstraint('event_id')
+    )
+    op.create_index(op.f('ix_iam_events_actor_user_id'), 'iam_events', ['actor_user_id'], unique=False)
+    op.create_index(op.f('ix_iam_events_event_type'), 'iam_events', ['event_type'], unique=False)
+    op.create_index(op.f('ix_iam_events_occurred_on'), 'iam_events', ['occurred_on'], unique=False)
+
+    op.create_table('vault_events',
+    sa.Column('event_id', sa.Uuid(), nullable=False),
+    sa.Column('event_type', sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+    sa.Column('occurred_on', sa.DateTime(), nullable=False),
+    sa.Column('actor_user_id', sa.Uuid(), nullable=True),
+    sa.Column('event_data', sa.JSON(), nullable=True),
+    sa.PrimaryKeyConstraint('event_id')
+    )
+    op.create_index(op.f('ix_vault_events_actor_user_id'), 'vault_events', ['actor_user_id'], unique=False)
+    op.create_index(op.f('ix_vault_events_event_type'), 'vault_events', ['event_type'], unique=False)
+    op.create_index(op.f('ix_vault_events_occurred_on'), 'vault_events', ['occurred_on'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_vault_events_occurred_on'), table_name='vault_events')
+    op.drop_index(op.f('ix_vault_events_event_type'), table_name='vault_events')
+    op.drop_index(op.f('ix_vault_events_actor_user_id'), table_name='vault_events')
+    op.drop_table('vault_events')
+
+    op.drop_index(op.f('ix_iam_events_occurred_on'), table_name='iam_events')
+    op.drop_index(op.f('ix_iam_events_event_type'), table_name='iam_events')
+    op.drop_index(op.f('ix_iam_events_actor_user_id'), table_name='iam_events')
+    op.drop_table('iam_events')

--- a/server/src/identity_access_management_context/adapters/primary/fastapi/app_dependencies.py
+++ b/server/src/identity_access_management_context/adapters/primary/fastapi/app_dependencies.py
@@ -50,8 +50,6 @@ from identity_access_management_context.adapters.secondary.sql import (
     SqlGroupMemberRepository,
     SqlSsoUserRepository,
     SqlSsoConfigurationRepository,
-)
-from identity_access_management_context.adapters.secondary.sql.sql_iam_event_repository import (
     SqlIamEventRepository,
 )
 from identity_access_management_context.application.gateways import IamEventRepository

--- a/server/src/identity_access_management_context/adapters/primary/fastapi/app_dependencies.py
+++ b/server/src/identity_access_management_context/adapters/primary/fastapi/app_dependencies.py
@@ -51,6 +51,10 @@ from identity_access_management_context.adapters.secondary.sql import (
     SqlSsoUserRepository,
     SqlSsoConfigurationRepository,
 )
+from identity_access_management_context.adapters.secondary.sql.sql_iam_event_repository import (
+    SqlIamEventRepository,
+)
+from identity_access_management_context.application.gateways import IamEventRepository
 from identity_access_management_context.adapters.secondary.private_api import (
     PrivateApiGroupUsageGateway,
 )
@@ -65,6 +69,10 @@ from shared_kernel.adapters.primary.dependencies import get_session
 
 def get_event_publisher(request: Request) -> DomainEventPublisher:
     return request.app.state.domain_event_publisher
+
+
+def get_iam_event_repository(session: Session = Depends(get_session)) -> IamEventRepository:
+    return SqlIamEventRepository(session)
 
 
 def get_group_repository(session: Session = Depends(get_session)) -> GroupRepository:
@@ -146,27 +154,31 @@ def get_delete_user_usecase(
         get_group_member_repository
     ),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return DeleteUserUseCase(
         user_repository,
         group_repository,
         group_member_repository,
         event_publisher,
+        iam_event_repository,
     )
 
 
 def get_promote_admin_usecase(
     user_repository: UserRepository = Depends(get_user_repository),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
-    return PromoteAdminUseCase(user_repository, event_publisher)
+    return PromoteAdminUseCase(user_repository, event_publisher, iam_event_repository)
 
 
 def get_update_user_usecase(
     user_repository: UserRepository = Depends(get_user_repository),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
-    return UpdateUserUseCase(user_repository, event_publisher)
+    return UpdateUserUseCase(user_repository, event_publisher, iam_event_repository)
 
 
 def get_update_user_password_usecase(
@@ -196,6 +208,7 @@ def get_create_user_usecase(
         get_password_hashing_gateway
     ),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return CreateUserUseCase(
         user_repository,
@@ -204,6 +217,7 @@ def get_create_user_usecase(
         group_member_repository,
         password_hashing_gateway,
         event_publisher,
+        iam_event_repository,
     )
 
 
@@ -231,6 +245,7 @@ def get_admin_login_usecase(
     token_gateway: TokenGateway = Depends(get_token_gateway),
     time_provider: TimeGateway = Depends(get_time_provider),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return AdminLoginUseCase(
         user_password_repository,
@@ -238,6 +253,7 @@ def get_admin_login_usecase(
         token_gateway,
         time_provider,
         event_publisher,
+        iam_event_repository,
     )
 
 
@@ -254,6 +270,7 @@ def get_register_admin_with_password_usecase(
     ),
     user_repository: UserRepository = Depends(get_user_repository),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return RegisterAdminWithPasswordUseCase(
         user_password_repository,
@@ -262,6 +279,7 @@ def get_register_admin_with_password_usecase(
         group_repository,
         group_member_repository,
         event_publisher,
+        iam_event_repository,
     )
 
 
@@ -292,9 +310,10 @@ def get_configure_sso_provider_usecase(
     ),
     sso_encryption_gateway: SsoEncryptionGateway = Depends(get_sso_encryption_gateway),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return ConfigureSsoProviderUseCase(
-        sso_gateway, sso_configuration_repository, sso_encryption_gateway, event_publisher
+        sso_gateway, sso_configuration_repository, sso_encryption_gateway, event_publisher, iam_event_repository
     )
 
 
@@ -324,6 +343,7 @@ def get_sso_login_usecase(
     ),
     sso_encryption_gateway: SsoEncryptionGateway = Depends(get_sso_encryption_gateway),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return SsoLoginUseCase(
         sso_gateway,
@@ -337,6 +357,7 @@ def get_sso_login_usecase(
         sso_configuration_repository,
         sso_encryption_gateway,
         event_publisher,
+        iam_event_repository,
     )
 
 
@@ -360,12 +381,14 @@ def get_create_group_usecase(
         get_group_member_repository
     ),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return CreateGroupUseCase(
         user_repository,
         group_repository,
         group_member_repository,
         event_publisher,
+        iam_event_repository,
     )
 
 
@@ -376,12 +399,14 @@ def get_add_user_to_group_usecase(
         get_group_member_repository
     ),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return AddUserToGroupUseCase(
         user_repository,
         group_repository,
         group_member_repository,
         event_publisher,
+        iam_event_repository,
     )
 
 
@@ -392,12 +417,14 @@ def get_add_owner_to_group_usecase(
         get_group_member_repository
     ),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return AddOwnerToGroupUseCase(
         user_repository,
         group_repository,
         group_member_repository,
         event_publisher,
+        iam_event_repository,
     )
 
 
@@ -408,12 +435,14 @@ def get_remove_user_from_group_usecase(
         get_group_member_repository
     ),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return RemoveUserFromGroupUseCase(
         user_repository,
         group_repository,
         group_member_repository,
         event_publisher,
+        iam_event_repository,
     )
 
 
@@ -449,8 +478,9 @@ def get_update_group_usecase(
         get_group_member_repository
     ),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
-    return UpdateGroupUseCase(group_repository, group_member_repository, event_publisher)
+    return UpdateGroupUseCase(group_repository, group_member_repository, event_publisher, iam_event_repository)
 
 
 def get_delete_group_usecase(
@@ -460,7 +490,8 @@ def get_delete_group_usecase(
     ),
     group_usage_gateway: GroupUsageGateway = Depends(get_group_usage_gateway),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    iam_event_repository: IamEventRepository = Depends(get_iam_event_repository),
 ):
     return DeleteGroupUseCase(
-        group_repository, group_member_repository, group_usage_gateway, event_publisher
+        group_repository, group_member_repository, group_usage_gateway, event_publisher, iam_event_repository
     )

--- a/server/src/identity_access_management_context/adapters/secondary/sql/__init__.py
+++ b/server/src/identity_access_management_context/adapters/secondary/sql/__init__.py
@@ -1,11 +1,13 @@
 from .model.group_model import GroupTable
 from .model.group_member_model import GroupMemberTable
+from .model.iam_event import IamEventTable
 from .model.sso_configuration_model import SsoConfigurationTable
 from .model.sso_users_model import SsoUsersTable
 from .model.users_model import UserTable
 from .model.user_password_model import UserPasswordTable
 from .sql_group_repository import SqlGroupRepository
 from .sql_group_member_repository import SqlGroupMemberRepository
+from .sql_iam_event_repository import SqlIamEventRepository
 from .sql_user_repository import SqlUserRepository
 from .sql_user_password_repository import SqlUserPasswordRepository
 from .sql_sso_user_repository import SqlSsoUserRepository
@@ -15,12 +17,14 @@ from .sql_sso_configuration_repository import SqlSsoConfigurationRepository
 __all__ = [
     "SqlGroupRepository",
     "SqlGroupMemberRepository",
+    "SqlIamEventRepository",
     "SqlUserRepository",
     "SqlUserPasswordRepository",
     "SqlSsoUserRepository",
     "SqlSsoConfigurationRepository",
     "GroupTable",
     "GroupMemberTable",
+    "IamEventTable",
     "SsoConfigurationTable",
     "SsoUsersTable",
     "UserTable",

--- a/server/src/identity_access_management_context/adapters/secondary/sql/model/iam_event.py
+++ b/server/src/identity_access_management_context/adapters/secondary/sql/model/iam_event.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from uuid import UUID
+from sqlmodel import Field, SQLModel, JSON, Column
+
+
+class IamEventTable(SQLModel, table=True):
+    """SQLModel table for IAM audit events"""
+
+    __tablename__: str = "iam_events"
+
+    event_id: UUID = Field(primary_key=True)
+    event_type: str = Field(index=True)
+    occurred_on: datetime = Field(index=True)
+    actor_user_id: UUID | None = Field(default=None, index=True)
+    event_data: dict = Field(default_factory=dict, sa_column=Column(JSON))

--- a/server/src/identity_access_management_context/adapters/secondary/sql/sql_iam_event_repository.py
+++ b/server/src/identity_access_management_context/adapters/secondary/sql/sql_iam_event_repository.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from uuid import UUID
+from sqlmodel import Session
+
+from identity_access_management_context.adapters.secondary.sql.model.iam_event import (
+    IamEventTable,
+)
+from shared_kernel.adapters.secondary.sql.sql_base_repository import SQLBaseRepository
+
+
+class SqlIamEventRepository(SQLBaseRepository):
+    """SQL implementation of IAM event repository"""
+
+    def __init__(self, session: Session):
+        super().__init__(session)
+
+    def append_event(
+        self,
+        event_id: UUID,
+        event_type: str,
+        occurred_on: datetime,
+        actor_user_id: UUID | None,
+        event_data: dict,
+    ) -> None:
+        """Append an IAM event to storage"""
+        event = IamEventTable(
+            event_id=event_id,
+            event_type=event_type,
+            occurred_on=occurred_on,
+            actor_user_id=actor_user_id,
+            event_data=event_data,
+        )
+        self._session.add(event)
+        self.commit()

--- a/server/src/identity_access_management_context/application/gateways/__init__.py
+++ b/server/src/identity_access_management_context/application/gateways/__init__.py
@@ -9,6 +9,7 @@ from .user_password_repository import UserPasswordRepository
 from .group_repository import GroupRepository
 from .group_member_repository import GroupMemberRepository
 from .group_usage_gateway import GroupUsageGateway
+from .iam_event_repository import IamEventRepository
 
 __all__ = [
     "UserRepository",
@@ -25,4 +26,5 @@ __all__ = [
     "GroupRepository",
     "GroupMemberRepository",
     "GroupUsageGateway",
+    "IamEventRepository",
 ]

--- a/server/src/identity_access_management_context/application/gateways/iam_event_repository.py
+++ b/server/src/identity_access_management_context/application/gateways/iam_event_repository.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from typing import Protocol
+from uuid import UUID
+
+
+class IamEventRepository(Protocol):
+    """Repository for IAM audit events"""
+
+    def append_event(
+        self,
+        event_id: UUID,
+        event_type: str,
+        occurred_on: datetime,
+        actor_user_id: UUID | None,
+        event_data: dict,
+    ) -> None:
+        """Append an IAM event to storage"""
+        ...

--- a/server/src/identity_access_management_context/application/use_cases/add_owner_to_group_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/add_owner_to_group_use_case.py
@@ -5,6 +5,7 @@ from identity_access_management_context.application.gateways import (
     UserRepository,
     GroupRepository,
     GroupMemberRepository,
+    IamEventRepository,
 )
 from identity_access_management_context.domain.events import OwnerAddedToGroupEvent
 from identity_access_management_context.domain.exceptions import (
@@ -24,11 +25,13 @@ class AddOwnerToGroupUseCase:
         group_repository: GroupRepository,
         group_member_repository: GroupMemberRepository,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self.user_repository = user_repository
         self.group_repository = group_repository
         self.group_member_repository = group_member_repository
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     def execute(self, command: AddOwnerToGroupCommand) -> None:
         group = self.group_repository.get_by_id(command.group_id)
@@ -56,8 +59,16 @@ class AddOwnerToGroupUseCase:
             command.group_id, command.user_id, is_owner=True
         )
 
-        self._event_publisher.publish(OwnerAddedToGroupEvent(
+        event = OwnerAddedToGroupEvent(
             group_id=command.group_id,
             user_id=command.user_id,
             added_by_user_id=command.requester_id,
-        ))
+        )
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=command.requester_id,
+            event_data={"group_id": str(command.group_id), "user_id": str(command.user_id)},
+        )

--- a/server/src/identity_access_management_context/application/use_cases/add_user_to_group_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/add_user_to_group_use_case.py
@@ -5,6 +5,7 @@ from identity_access_management_context.application.gateways import (
     UserRepository,
     GroupRepository,
     GroupMemberRepository,
+    IamEventRepository,
 )
 from identity_access_management_context.domain.events import UserAddedToGroupEvent
 from identity_access_management_context.domain.exceptions import (
@@ -23,11 +24,13 @@ class AddUserToGroupUseCase:
         group_repository: GroupRepository,
         group_member_repository: GroupMemberRepository,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self.user_repository = user_repository
         self.group_repository = group_repository
         self.group_member_repository = group_member_repository
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     def execute(self, command: AddUserToGroupCommand) -> None:
         group = self.group_repository.get_by_id(command.group_id)
@@ -52,8 +55,16 @@ class AddUserToGroupUseCase:
             self.group_member_repository.add_member(
                 command.group_id, command.user_id, is_owner=False
             )
-            self._event_publisher.publish(UserAddedToGroupEvent(
+            event = UserAddedToGroupEvent(
                 group_id=command.group_id,
                 user_id=command.user_id,
                 added_by_user_id=command.requester_id,
-            ))
+            )
+            self._event_publisher.publish(event)
+            self._iam_event_repository.append_event(
+                event_id=event.event_id,
+                event_type=type(event).__name__,
+                occurred_on=event.occurred_on,
+                actor_user_id=command.requester_id,
+                event_data={"group_id": str(command.group_id), "user_id": str(command.user_id)},
+            )

--- a/server/src/identity_access_management_context/application/use_cases/admin/admin_login_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/admin/admin_login_use_case.py
@@ -1,3 +1,5 @@
+import logging
+
 from identity_access_management_context.application.commands import AdminLoginCommand
 from identity_access_management_context.application.responses import AdminLoginResponse
 from identity_access_management_context.application.gateways import (
@@ -13,6 +15,8 @@ from identity_access_management_context.domain.exceptions import (
 )
 from shared_kernel.domain.value_objects.constants import ADMIN_ROLE
 from shared_kernel.application.gateways import DomainEventPublisher, TimeGateway
+
+logger = logging.getLogger(__name__)
 
 
 class AdminLoginUseCase:
@@ -35,6 +39,7 @@ class AdminLoginUseCase:
     async def execute(self, command: AdminLoginCommand) -> AdminLoginResponse:
         user_password = self._user_password_repository.get_by_email(command.email)
         if not user_password:
+            logger.warning("Login failed for email=%s reason='User not found'", command.email)
             event = AdminLoginFailedEvent(email=command.email, reason="User not found")
             self._event_publisher.publish(event)
             self._iam_event_repository.append_event(
@@ -49,6 +54,7 @@ class AdminLoginUseCase:
         if not self._password_hashing_gateway.verify(
             command.password, user_password.password_hash
         ):
+            logger.warning("Login failed for email=%s reason='Invalid credentials'", command.email)
             event = AdminLoginFailedEvent(email=command.email, reason="Invalid credentials")
             self._event_publisher.publish(event)
             self._iam_event_repository.append_event(

--- a/server/src/identity_access_management_context/application/use_cases/admin/admin_login_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/admin/admin_login_use_case.py
@@ -4,6 +4,7 @@ from identity_access_management_context.application.gateways import (
     UserPasswordRepository,
     PasswordHashingGateway,
     TokenGateway,
+    IamEventRepository,
 )
 from identity_access_management_context.domain.events import AdminLoginEvent, AdminLoginFailedEvent
 from identity_access_management_context.domain.exceptions import (
@@ -22,29 +23,41 @@ class AdminLoginUseCase:
         token_gateway: TokenGateway,
         time_provider: TimeGateway,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self._user_password_repository = user_password_repository
         self._password_hashing_gateway = password_hashing_gateway
         self._token_gateway = token_gateway
         self._time_provider = time_provider
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     async def execute(self, command: AdminLoginCommand) -> AdminLoginResponse:
         user_password = self._user_password_repository.get_by_email(command.email)
         if not user_password:
-            self._event_publisher.publish(AdminLoginFailedEvent(
-                email=command.email,
-                reason="User not found",
-            ))
+            event = AdminLoginFailedEvent(email=command.email, reason="User not found")
+            self._event_publisher.publish(event)
+            self._iam_event_repository.append_event(
+                event_id=event.event_id,
+                event_type=type(event).__name__,
+                occurred_on=event.occurred_on,
+                actor_user_id=None,
+                event_data={"email": command.email, "reason": "User not found"},
+            )
             raise AdminNotFoundException("User not found")
 
         if not self._password_hashing_gateway.verify(
             command.password, user_password.password_hash
         ):
-            self._event_publisher.publish(AdminLoginFailedEvent(
-                email=command.email,
-                reason="Invalid credentials",
-            ))
+            event = AdminLoginFailedEvent(email=command.email, reason="Invalid credentials")
+            self._event_publisher.publish(event)
+            self._iam_event_repository.append_event(
+                event_id=event.event_id,
+                event_type=type(event).__name__,
+                occurred_on=event.occurred_on,
+                actor_user_id=None,
+                event_data={"email": command.email, "reason": "Invalid credentials"},
+            )
             raise InvalidCredentialsException("Invalid credentials")
 
         token = await self._token_gateway.generate_token(
@@ -60,10 +73,15 @@ class AdminLoginUseCase:
             roles=[ADMIN_ROLE],
         )
 
-        self._event_publisher.publish(AdminLoginEvent(
-            admin_id=user_password.id,
-            email=user_password.email,
-        ))
+        event = AdminLoginEvent(admin_id=user_password.id, email=user_password.email)
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=user_password.id,
+            event_data={"email": user_password.email},
+        )
 
         return AdminLoginResponse(
             jwt_token=token.value,

--- a/server/src/identity_access_management_context/application/use_cases/admin/register_admin_with_password_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/admin/register_admin_with_password_use_case.py
@@ -9,6 +9,7 @@ from identity_access_management_context.application.gateways import (
     UserRepository,
     GroupRepository,
     GroupMemberRepository,
+    IamEventRepository,
 )
 from identity_access_management_context.application.services import (
     UserManagementService,
@@ -31,6 +32,7 @@ class RegisterAdminWithPasswordUseCase:
         group_repository: GroupRepository,
         group_member_repository: GroupMemberRepository,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self._user_password_repository = user_password_repository
         self._password_hashing_gateway = password_hashing_gateway
@@ -38,6 +40,7 @@ class RegisterAdminWithPasswordUseCase:
         self._group_repository = group_repository
         self._group_member_repository = group_member_repository
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     async def execute(self, command: RegisterAdminWithPasswordCommand) -> UUID:
         # Create service instance
@@ -75,9 +78,14 @@ class RegisterAdminWithPasswordUseCase:
             group_member_repository=self._group_member_repository,
         )
 
-        self._event_publisher.publish(AdminRegisteredEvent(
-            admin_id=user_password.id,
-            email=command.email,
-        ))
+        event = AdminRegisteredEvent(admin_id=user_password.id, email=command.email)
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=user_password.id,
+            event_data={"email": command.email},
+        )
 
         return user_password.id

--- a/server/src/identity_access_management_context/application/use_cases/create_group_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/create_group_use_case.py
@@ -5,6 +5,7 @@ from identity_access_management_context.application.gateways import (
     UserRepository,
     GroupRepository,
     GroupMemberRepository,
+    IamEventRepository,
 )
 from identity_access_management_context.domain.entities import Group
 from identity_access_management_context.domain.events import GroupCreatedEvent
@@ -19,11 +20,13 @@ class CreateGroupUseCase:
         group_repository: GroupRepository,
         group_member_repository: GroupMemberRepository,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self.user_repository = user_repository
         self.group_repository = group_repository
         self.group_member_repository = group_member_repository
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     def execute(self, command: CreateGroupCommand) -> UUID:
         user = self.user_repository.get_by_id(command.creator_id)
@@ -41,10 +44,18 @@ class CreateGroupUseCase:
             command.id, command.creator_id, is_owner=True
         )
 
-        self._event_publisher.publish(GroupCreatedEvent(
+        event = GroupCreatedEvent(
             group_id=group.id,
             group_name=group.name,
             created_by_user_id=command.creator_id,
-        ))
+        )
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=command.creator_id,
+            event_data={"group_id": str(group.id), "group_name": group.name},
+        )
 
         return group.id

--- a/server/src/identity_access_management_context/application/use_cases/create_user_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/create_user_use_case.py
@@ -7,6 +7,7 @@ from identity_access_management_context.application.gateways import (
     GroupRepository,
     GroupMemberRepository,
     PasswordHashingGateway,
+    IamEventRepository,
 )
 from identity_access_management_context.application.services import UserCreationService
 from identity_access_management_context.domain.entities import User, UserPassword
@@ -24,6 +25,7 @@ class CreateUserUseCase:
         group_member_repository: GroupMemberRepository,
         password_hashing_gateway: PasswordHashingGateway,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self.user_repository = user_repository
         self.user_password_repository = user_password_repository
@@ -31,6 +33,7 @@ class CreateUserUseCase:
         self.group_member_repository = group_member_repository
         self.password_hashing_gateway = password_hashing_gateway
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     def execute(self, command: CreateUserCommand) -> UUID:
         AdminPermissionChecker().ensure_admin(command.requesting_user, "Create User")
@@ -62,11 +65,19 @@ class CreateUserUseCase:
             group_member_repository=self.group_member_repository,
         )
 
-        self._event_publisher.publish(UserCreatedEvent(
+        event = UserCreatedEvent(
             user_id=user.id,
             username=user.username,
             email=user.email,
             created_by_user_id=command.requesting_user.user_id,
-        ))
+        )
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=command.requesting_user.user_id,
+            event_data={"user_id": str(user.id), "username": user.username, "email": user.email},
+        )
 
         return user.id

--- a/server/src/identity_access_management_context/application/use_cases/delete_group_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/delete_group_use_case.py
@@ -3,6 +3,7 @@ from identity_access_management_context.application.gateways import (
     GroupRepository,
     GroupMemberRepository,
     GroupUsageGateway,
+    IamEventRepository,
 )
 from identity_access_management_context.domain.events import GroupDeletedEvent
 from identity_access_management_context.domain.exceptions import (
@@ -22,11 +23,13 @@ class DeleteGroupUseCase:
         group_member_repository: GroupMemberRepository,
         group_usage_gateway: GroupUsageGateway,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self.group_repository = group_repository
         self.group_member_repository = group_member_repository
         self.group_usage_gateway = group_usage_gateway
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     def execute(self, command: DeleteGroupCommand) -> None:
         group = self.group_repository.get_by_id(command.group_id)
@@ -53,7 +56,15 @@ class DeleteGroupUseCase:
         self.group_member_repository.delete_by_group_id(command.group_id)
         self.group_repository.delete_group(command.group_id)
 
-        self._event_publisher.publish(GroupDeletedEvent(
+        event = GroupDeletedEvent(
             group_id=command.group_id,
             deleted_by_user_id=command.requesting_user.user_id,
-        ))
+        )
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=command.requesting_user.user_id,
+            event_data={"group_id": str(command.group_id)},
+        )

--- a/server/src/identity_access_management_context/application/use_cases/delete_user_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/delete_user_use_case.py
@@ -2,6 +2,7 @@ from identity_access_management_context.application.gateways import (
     UserRepository,
     GroupRepository,
     GroupMemberRepository,
+    IamEventRepository,
 )
 from identity_access_management_context.application.commands import DeleteUserCommand
 from identity_access_management_context.domain.events import UserDeletedEvent
@@ -16,11 +17,13 @@ class DeleteUserUseCase:
         group_repository: GroupRepository,
         group_member_repository: GroupMemberRepository,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self.user_repository = user_repository
         self.group_repository = group_repository
         self.group_member_repository = group_member_repository
         self.event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     def execute(self, command: DeleteUserCommand) -> None:
         AdminPermissionChecker().ensure_admin(command.requesting_user, "delete users")
@@ -52,6 +55,13 @@ class DeleteUserUseCase:
             personal_group_id=personal_group_id,
         )
         self.event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=command.requesting_user.user_id,
+            event_data={"user_id": str(user_id), "personal_group_id": str(personal_group_id) if personal_group_id else None},
+        )
 
         # Delete personal group after event (so password context can clean up)
         if personal_group:

--- a/server/src/identity_access_management_context/application/use_cases/promote_admin_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/promote_admin_use_case.py
@@ -1,5 +1,5 @@
 from identity_access_management_context.application.commands import PromoteAdminCommand
-from identity_access_management_context.application.gateways import UserRepository
+from identity_access_management_context.application.gateways import UserRepository, IamEventRepository
 from identity_access_management_context.domain.events import AdminPromotedEvent
 from identity_access_management_context.domain.exceptions import UserNotFoundException
 from shared_kernel.application.gateways import DomainEventPublisher
@@ -7,9 +7,10 @@ from shared_kernel.domain.services import AdminPermissionChecker
 
 
 class PromoteAdminUseCase:
-    def __init__(self, user_repository: UserRepository, event_publisher: DomainEventPublisher):
+    def __init__(self, user_repository: UserRepository, event_publisher: DomainEventPublisher, iam_event_repository: IamEventRepository):
         self.user_repository = user_repository
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     def execute(self, command: PromoteAdminCommand) -> None:
         AdminPermissionChecker.ensure_admin(
@@ -23,7 +24,15 @@ class PromoteAdminUseCase:
         user.promote_to_admin()
         self.user_repository.update(user)
 
-        self._event_publisher.publish(AdminPromotedEvent(
+        event = AdminPromotedEvent(
             user_id=command.user_id,
             promoted_by_user_id=command.requesting_user.user_id,
-        ))
+        )
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=command.requesting_user.user_id,
+            event_data={"user_id": str(command.user_id)},
+        )

--- a/server/src/identity_access_management_context/application/use_cases/remove_user_from_group_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/remove_user_from_group_use_case.py
@@ -5,6 +5,7 @@ from identity_access_management_context.application.gateways import (
     UserRepository,
     GroupRepository,
     GroupMemberRepository,
+    IamEventRepository,
 )
 from identity_access_management_context.domain.events import UserRemovedFromGroupEvent
 from identity_access_management_context.domain.exceptions import (
@@ -24,11 +25,13 @@ class RemoveUserFromGroupUseCase:
         group_repository: GroupRepository,
         group_member_repository: GroupMemberRepository,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self.user_repository = user_repository
         self.group_repository = group_repository
         self.group_member_repository = group_member_repository
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     def execute(self, command: RemoveUserFromGroupCommand) -> None:
         group = self.group_repository.get_by_id(command.group_id)
@@ -53,8 +56,16 @@ class RemoveUserFromGroupUseCase:
 
         self.group_member_repository.remove_member(command.group_id, command.user_id)
 
-        self._event_publisher.publish(UserRemovedFromGroupEvent(
+        event = UserRemovedFromGroupEvent(
             group_id=command.group_id,
             user_id=command.user_id,
             removed_by_user_id=command.requester_id,
-        ))
+        )
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=command.requester_id,
+            event_data={"group_id": str(command.group_id), "user_id": str(command.user_id)},
+        )

--- a/server/src/identity_access_management_context/application/use_cases/sso/configure_sso_provider_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/sso/configure_sso_provider_use_case.py
@@ -7,6 +7,7 @@ from identity_access_management_context.application.gateways import (
     SsoGateway,
     SsoConfigurationRepository,
     SsoEncryptionGateway,
+    IamEventRepository,
 )
 from identity_access_management_context.domain.entities import SsoConfiguration
 from identity_access_management_context.domain.events import SsoConfiguredEvent
@@ -33,11 +34,13 @@ class ConfigureSsoProviderUseCase:
         sso_configuration_repository: SsoConfigurationRepository,
         sso_encryption_gateway: SsoEncryptionGateway,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self._sso_gateway = sso_gateway
         self._sso_configuration_repository = sso_configuration_repository
         self._sso_encryption_gateway = sso_encryption_gateway
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     async def execute(self, command: ConfigureSsoProviderCommand) -> None:
         """
@@ -84,10 +87,18 @@ class ConfigureSsoProviderUseCase:
             )
             self._sso_configuration_repository.save(config)
 
-            self._event_publisher.publish(SsoConfiguredEvent(
+            event = SsoConfiguredEvent(
                 configured_by_user_id=command.requesting_user.user_id,
                 discovery_url=command.discovery_url,
-            ))
+            )
+            self._event_publisher.publish(event)
+            self._iam_event_repository.append_event(
+                event_id=event.event_id,
+                event_type=type(event).__name__,
+                occurred_on=event.occurred_on,
+                actor_user_id=command.requesting_user.user_id,
+                event_data={"discovery_url": command.discovery_url},
+            )
 
         except ValueError as e:
             raise InvalidSsoSettingsException(f"Auto-discovery failed: {str(e)}")

--- a/server/src/identity_access_management_context/application/use_cases/sso/sso_login_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/sso/sso_login_use_case.py
@@ -26,6 +26,7 @@ from identity_access_management_context.application.services import (
     SsoConfigurationDecryptingService,
 )
 from identity_access_management_context.domain.entities.sso_user import SsoUser
+from identity_access_management_context.application.gateways import IamEventRepository
 from identity_access_management_context.domain.events import SsoLoginEvent
 from shared_kernel.application.gateways import DomainEventPublisher, TimeGateway
 
@@ -54,6 +55,7 @@ class SsoLoginUseCase:
         sso_configuration_repository: SsoConfigurationRepository,
         sso_encryption_gateway: SsoEncryptionGateway,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self._sso_gateway = sso_gateway
         self._sso_user_repository = sso_user_repository
@@ -66,6 +68,7 @@ class SsoLoginUseCase:
         self._sso_configuration_repository = sso_configuration_repository
         self._sso_encryption_gateway = sso_encryption_gateway
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     async def execute(self, command: SsoLoginCommand) -> SsoLoginResponse:
         # Step 0: Retrieve SSO and decrypt secret key
@@ -148,11 +151,15 @@ class SsoLoginUseCase:
             roles=["user"],
         )
 
-        self._event_publisher.publish(SsoLoginEvent(
-            user_id=user_id,
-            email=email,
-            is_new_user=is_new_user,
-        ))
+        event = SsoLoginEvent(user_id=user_id, email=email, is_new_user=is_new_user)
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=user_id,
+            event_data={"email": email, "is_new_user": is_new_user},
+        )
 
         return SsoLoginResponse(
             jwt_token=token.value,

--- a/server/src/identity_access_management_context/application/use_cases/update_group_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/update_group_use_case.py
@@ -4,6 +4,7 @@ from identity_access_management_context.application.commands import (
 from identity_access_management_context.application.gateways import (
     GroupRepository,
     GroupMemberRepository,
+    IamEventRepository,
 )
 from identity_access_management_context.domain.events import GroupUpdatedEvent
 from identity_access_management_context.domain.exceptions import (
@@ -21,10 +22,12 @@ class UpdateGroupUseCase:
         group_repository: GroupRepository,
         group_member_repository: GroupMemberRepository,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self.group_repository = group_repository
         self.group_member_repository = group_member_repository
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     def execute(self, command: UpdateGroupCommand) -> None:
         group = self.group_repository.get_by_id(command.group_id)
@@ -44,8 +47,16 @@ class UpdateGroupUseCase:
         group.name = command.name
         self.group_repository.save_group(group)
 
-        self._event_publisher.publish(GroupUpdatedEvent(
+        event = GroupUpdatedEvent(
             group_id=command.group_id,
             new_name=command.name,
             updated_by_user_id=command.requesting_user.user_id,
-        ))
+        )
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=command.requesting_user.user_id,
+            event_data={"group_id": str(command.group_id), "new_name": command.name},
+        )

--- a/server/src/identity_access_management_context/application/use_cases/update_user_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/update_user_use_case.py
@@ -1,4 +1,4 @@
-from identity_access_management_context.application.gateways import UserRepository
+from identity_access_management_context.application.gateways import UserRepository, IamEventRepository
 from identity_access_management_context.application.commands import UpdateUserCommand
 from identity_access_management_context.domain.events import UserUpdatedEvent
 from identity_access_management_context.domain.exceptions import UserNotFoundError
@@ -11,9 +11,11 @@ class UpdateUserUseCase:
         self,
         user_repository: UserRepository,
         event_publisher: DomainEventPublisher,
+        iam_event_repository: IamEventRepository,
     ):
         self.user_repository = user_repository
         self._event_publisher = event_publisher
+        self._iam_event_repository = iam_event_repository
 
     def execute(self, command: UpdateUserCommand) -> UUID:
         user = self.user_repository.get_by_id(command.id)
@@ -26,9 +28,17 @@ class UpdateUserUseCase:
 
         self.user_repository.update(user)
 
-        self._event_publisher.publish(UserUpdatedEvent(
+        event = UserUpdatedEvent(
             user_id=command.id,
             updated_by_user_id=command.id,
-        ))
+        )
+        self._event_publisher.publish(event)
+        self._iam_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=command.id,
+            event_data={"user_id": str(command.id)},
+        )
 
         return user.id

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -168,7 +168,9 @@ async def lifespan(app: FastAPI):
     domain_event_publisher = InMemoryDomainEventPublisher()
     app.state.domain_event_publisher = domain_event_publisher
 
-    logger.info("Application started successfully")
+    db_url = get_database_url()
+    db_type = "postgresql" if db_url.startswith("postgresql") else "sqlite"
+    logger.info("Application started — db=%s base_url=%s", db_type, base_url)
     yield
     logger.info("Application shutting down")
 

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -14,6 +14,7 @@ from alembic import command
 
 def configure_logging():
     logging.basicConfig(
+        force=True,  # override uvicorn's pre-configured handlers
         level=logging.INFO,
         format="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -14,11 +14,15 @@ from alembic import command
 
 def configure_logging():
     logging.basicConfig(
-        force=True,  # override uvicorn's pre-configured handlers
+        force=True,  # override uvicorn's or alembic's pre-configured handlers
         level=logging.INFO,
         format="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
+    # alembic's fileConfig uses disable_existing_loggers=True by default,
+    # which marks all pre-existing loggers as disabled. Re-enable them.
+    for name in logging.Logger.manager.loggerDict:
+        logging.getLogger(name).disabled = False
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
 
@@ -111,6 +115,7 @@ async def lifespan(app: FastAPI):
     # Run migrations instead of create_tables
     logger.info("Starting database migrations...")
     run_migrations()
+    configure_logging()  # re-apply after alembic's fileConfig resets the root logger
     logger.info("Database migrations completed")
 
     engine = _build_engine(get_database_url())

--- a/server/src/shared_kernel/adapters/primary/logging_middleware.py
+++ b/server/src/shared_kernel/adapters/primary/logging_middleware.py
@@ -17,11 +17,20 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         duration_ms = (time.perf_counter() - start) * 1000
 
-        logger.info(
-            "%s %s %d %.0fms",
-            request.method,
-            request.url.path,
-            response.status_code,
-            duration_ms,
-        )
+        if duration_ms > 500:
+            logger.warning(
+                "Slow request %s %s %d %.0fms",
+                request.method,
+                request.url.path,
+                response.status_code,
+                duration_ms,
+            )
+        else:
+            logger.info(
+                "%s %s %d %.0fms",
+                request.method,
+                request.url.path,
+                response.status_code,
+                duration_ms,
+            )
         return response

--- a/server/src/vault_management_context/adapters/primary/fastapi/app_dependencies.py
+++ b/server/src/vault_management_context/adapters/primary/fastapi/app_dependencies.py
@@ -18,8 +18,6 @@ from vault_management_context.application.gateways import (
 )
 from vault_management_context.adapters.secondary import (
     SqlVaultRepository,
-)
-from vault_management_context.adapters.secondary.sql.sql_vault_event_repository import (
     SqlVaultEventRepository,
 )
 from vault_management_context.application.gateways import VaultEventRepository

--- a/server/src/vault_management_context/adapters/primary/fastapi/app_dependencies.py
+++ b/server/src/vault_management_context/adapters/primary/fastapi/app_dependencies.py
@@ -19,12 +19,20 @@ from vault_management_context.application.gateways import (
 from vault_management_context.adapters.secondary import (
     SqlVaultRepository,
 )
+from vault_management_context.adapters.secondary.sql.sql_vault_event_repository import (
+    SqlVaultEventRepository,
+)
+from vault_management_context.application.gateways import VaultEventRepository
 from shared_kernel.application.gateways import DomainEventPublisher
 from shared_kernel.adapters.primary.dependencies import get_session
 
 
 def get_event_publisher(request: Request) -> DomainEventPublisher:
     return request.app.state.domain_event_publisher
+
+
+def get_vault_event_repository(session: Session = Depends(get_session)) -> VaultEventRepository:
+    return SqlVaultEventRepository(session)
 
 
 def get_vault_repository(session: Session = Depends(get_session)) -> VaultRepository:
@@ -53,9 +61,10 @@ def get_create_vault_usecase(
     encryption_gateway: EncryptionGateway = Depends(get_encryption_gateway),
     vault_session_gateway: VaultSessionGateway = Depends(get_vault_session_gateway),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    vault_event_repository: VaultEventRepository = Depends(get_vault_event_repository),
 ):
     return CreateVaultUseCase(
-        vault_repository, shamir_gateway, encryption_gateway, vault_session_gateway, event_publisher
+        vault_repository, shamir_gateway, encryption_gateway, vault_session_gateway, event_publisher, vault_event_repository
     )
 
 
@@ -66,6 +75,7 @@ def get_unlock_vault_usecase(
     vault_session_gateway: VaultSessionGateway = Depends(get_vault_session_gateway),
     share_repository: ShareRepository = Depends(get_share_repository),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    vault_event_repository: VaultEventRepository = Depends(get_vault_event_repository),
 ):
     return UnlockVaultUseCase(
         vault_repository,
@@ -74,6 +84,7 @@ def get_unlock_vault_usecase(
         vault_session_gateway,
         share_repository,
         event_publisher,
+        vault_event_repository,
     )
 
 
@@ -81,8 +92,9 @@ def get_lock_vault_usecase(
     vault_repository: VaultRepository = Depends(get_vault_repository),
     vault_session_gateway: VaultSessionGateway = Depends(get_vault_session_gateway),
     event_publisher: DomainEventPublisher = Depends(get_event_publisher),
+    vault_event_repository: VaultEventRepository = Depends(get_vault_event_repository),
 ):
-    return LockVaultUseCase(vault_repository, vault_session_gateway, event_publisher)
+    return LockVaultUseCase(vault_repository, vault_session_gateway, event_publisher, vault_event_repository)
 
 
 def get_vault_status_usecase(

--- a/server/src/vault_management_context/adapters/secondary/__init__.py
+++ b/server/src/vault_management_context/adapters/secondary/__init__.py
@@ -5,6 +5,7 @@ from .in_memory_vault_session_gateway import InMemoryVaultSessionGateway
 from .in_memory_share_repository import InMemoryShareRepository
 
 from .sql.sql_vault_repository import SqlVaultRepository
+from .sql.sql_vault_event_repository import SqlVaultEventRepository
 
 __all__ = [
     "CryptoShamirGateway",
@@ -12,4 +13,5 @@ __all__ = [
     "InMemoryVaultSessionGateway",
     "InMemoryShareRepository",
     "SqlVaultRepository",
+    "SqlVaultEventRepository",
 ]

--- a/server/src/vault_management_context/adapters/secondary/sql/__init__.py
+++ b/server/src/vault_management_context/adapters/secondary/sql/__init__.py
@@ -1,5 +1,7 @@
 from .models.vault import VaultTable
+from .models.vault_event import VaultEventTable
 from .sql_vault_repository import SqlVaultRepository
+from .sql_vault_event_repository import SqlVaultEventRepository
 
 
-__all__ = ["VaultTable", "SqlVaultRepository"]
+__all__ = ["VaultTable", "VaultEventTable", "SqlVaultRepository", "SqlVaultEventRepository"]

--- a/server/src/vault_management_context/adapters/secondary/sql/models/vault_event.py
+++ b/server/src/vault_management_context/adapters/secondary/sql/models/vault_event.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from uuid import UUID
+from sqlmodel import Field, SQLModel, JSON, Column
+
+
+class VaultEventTable(SQLModel, table=True):
+    """SQLModel table for vault audit events"""
+
+    __tablename__: str = "vault_events"
+
+    event_id: UUID = Field(primary_key=True)
+    event_type: str = Field(index=True)
+    occurred_on: datetime = Field(index=True)
+    actor_user_id: UUID | None = Field(default=None, index=True)
+    event_data: dict = Field(default_factory=dict, sa_column=Column(JSON))

--- a/server/src/vault_management_context/adapters/secondary/sql/sql_vault_event_repository.py
+++ b/server/src/vault_management_context/adapters/secondary/sql/sql_vault_event_repository.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from uuid import UUID
+from sqlmodel import Session
+
+from vault_management_context.adapters.secondary.sql.models.vault_event import (
+    VaultEventTable,
+)
+from shared_kernel.adapters.secondary.sql.sql_base_repository import SQLBaseRepository
+
+
+class SqlVaultEventRepository(SQLBaseRepository):
+    """SQL implementation of vault event repository"""
+
+    def __init__(self, session: Session):
+        super().__init__(session)
+
+    def append_event(
+        self,
+        event_id: UUID,
+        event_type: str,
+        occurred_on: datetime,
+        actor_user_id: UUID | None,
+        event_data: dict,
+    ) -> None:
+        """Append a vault event to storage"""
+        event = VaultEventTable(
+            event_id=event_id,
+            event_type=event_type,
+            occurred_on=occurred_on,
+            actor_user_id=actor_user_id,
+            event_data=event_data,
+        )
+        self._session.add(event)
+        self.commit()

--- a/server/src/vault_management_context/application/gateways/__init__.py
+++ b/server/src/vault_management_context/application/gateways/__init__.py
@@ -3,6 +3,7 @@ from .shamir_gateway import ShamirGateway
 from .encryption_gateway import EncryptionGateway
 from .vault_session_gateway import VaultSessionGateway
 from .share_repository import ShareRepository
+from .vault_event_repository import VaultEventRepository
 
 __all__ = [
     "VaultRepository",
@@ -10,4 +11,5 @@ __all__ = [
     "EncryptionGateway",
     "VaultSessionGateway",
     "ShareRepository",
+    "VaultEventRepository",
 ]

--- a/server/src/vault_management_context/application/gateways/vault_event_repository.py
+++ b/server/src/vault_management_context/application/gateways/vault_event_repository.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from typing import Protocol
+from uuid import UUID
+
+
+class VaultEventRepository(Protocol):
+    """Repository for vault audit events"""
+
+    def append_event(
+        self,
+        event_id: UUID,
+        event_type: str,
+        occurred_on: datetime,
+        actor_user_id: UUID | None,
+        event_data: dict,
+    ) -> None:
+        """Append a vault event to storage"""
+        ...

--- a/server/src/vault_management_context/application/use_cases/create_vault_use_case.py
+++ b/server/src/vault_management_context/application/use_cases/create_vault_use_case.py
@@ -11,6 +11,7 @@ from vault_management_context.application.gateways import (
     ShamirGateway,
     EncryptionGateway,
     VaultSessionGateway,
+    VaultEventRepository,
 )
 from vault_management_context.application.services import KeySessionManager
 from vault_management_context.application.responses.vault_setup_response import (
@@ -28,12 +29,14 @@ class CreateVaultUseCase:
         encryption_gateway: EncryptionGateway,
         vault_session_gateway: VaultSessionGateway,
         event_publisher: DomainEventPublisher,
+        vault_event_repository: VaultEventRepository,
     ) -> None:
         self.vault_repo = vault_repo
         self.shamir_gateway = shamir_gateway
         self.encryption_gateway = encryption_gateway
         self.vault_session_gateway = vault_session_gateway
         self._event_publisher = event_publisher
+        self._vault_event_repository = vault_event_repository
 
     def execute(self, command: CreateVaultCommand) -> VaultSetupResponse:
         existing_vault: Optional[Vault] = self.vault_repo.get()
@@ -65,11 +68,19 @@ class CreateVaultUseCase:
 
         self.vault_repo.save(vault)
 
-        self._event_publisher.publish(VaultCreatedEvent(
+        event = VaultCreatedEvent(
             setup_id=str(command.setup_id),
             nb_shares=command.nb_shares,
             threshold=command.threshold,
-        ))
+        )
+        self._event_publisher.publish(event)
+        self._vault_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=None,
+            event_data={"setup_id": str(command.setup_id), "nb_shares": command.nb_shares, "threshold": command.threshold},
+        )
 
         return VaultSetupResponse(
             setup_id=str(command.setup_id), shares=shamir_result.shares

--- a/server/src/vault_management_context/application/use_cases/create_vault_use_case.py
+++ b/server/src/vault_management_context/application/use_cases/create_vault_use_case.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 from vault_management_context.application.commands import CreateVaultCommand
@@ -19,6 +20,8 @@ from vault_management_context.application.responses.vault_setup_response import 
 )
 from vault_management_context.domain.events import VaultCreatedEvent
 from shared_kernel.application.gateways import DomainEventPublisher
+
+logger = logging.getLogger(__name__)
 
 
 class CreateVaultUseCase:
@@ -68,6 +71,7 @@ class CreateVaultUseCase:
 
         self.vault_repo.save(vault)
 
+        logger.info("Vault created (nb_shares=%d, threshold=%d)", command.nb_shares, command.threshold)
         event = VaultCreatedEvent(
             setup_id=str(command.setup_id),
             nb_shares=command.nb_shares,

--- a/server/src/vault_management_context/application/use_cases/lock_vault_use_case.py
+++ b/server/src/vault_management_context/application/use_cases/lock_vault_use_case.py
@@ -2,6 +2,7 @@ from vault_management_context.application.commands import LockVaultCommand
 from vault_management_context.application.gateways import (
     VaultRepository,
     VaultSessionGateway,
+    VaultEventRepository,
 )
 from vault_management_context.domain.exceptions import (
     VaultNotSetupException,
@@ -18,10 +19,12 @@ class LockVaultUseCase:
         vault_repository: VaultRepository,
         vault_session_gateway: VaultSessionGateway,
         event_publisher: DomainEventPublisher,
+        vault_event_repository: VaultEventRepository,
     ):
         self._vault_repository = vault_repository
         self._vault_session_gateway = vault_session_gateway
         self._event_publisher = event_publisher
+        self._vault_event_repository = vault_event_repository
 
     def execute(self, command: LockVaultCommand) -> None:
         """Lock the vault by clearing the decrypted key from memory"""
@@ -38,6 +41,12 @@ class LockVaultUseCase:
 
         self._vault_session_gateway.clear_decrypted_key()
 
-        self._event_publisher.publish(VaultLockedEvent(
-            locked_by_user_id=command.requesting_user.user_id,
-        ))
+        event = VaultLockedEvent(locked_by_user_id=command.requesting_user.user_id)
+        self._event_publisher.publish(event)
+        self._vault_event_repository.append_event(
+            event_id=event.event_id,
+            event_type=type(event).__name__,
+            occurred_on=event.occurred_on,
+            actor_user_id=command.requesting_user.user_id,
+            event_data={},
+        )

--- a/server/src/vault_management_context/application/use_cases/lock_vault_use_case.py
+++ b/server/src/vault_management_context/application/use_cases/lock_vault_use_case.py
@@ -1,4 +1,7 @@
+import logging
+
 from vault_management_context.application.commands import LockVaultCommand
+
 from vault_management_context.application.gateways import (
     VaultRepository,
     VaultSessionGateway,
@@ -11,6 +14,8 @@ from vault_management_context.domain.exceptions import (
 from shared_kernel.domain.services import AdminPermissionChecker
 from vault_management_context.domain.events import VaultLockedEvent
 from shared_kernel.application.gateways import DomainEventPublisher
+
+logger = logging.getLogger(__name__)
 
 
 class LockVaultUseCase:
@@ -41,6 +46,7 @@ class LockVaultUseCase:
 
         self._vault_session_gateway.clear_decrypted_key()
 
+        logger.info("Vault locked by user=%s", command.requesting_user.user_id)
         event = VaultLockedEvent(locked_by_user_id=command.requesting_user.user_id)
         self._event_publisher.publish(event)
         self._vault_event_repository.append_event(

--- a/server/src/vault_management_context/application/use_cases/unlock_vault_use_case.py
+++ b/server/src/vault_management_context/application/use_cases/unlock_vault_use_case.py
@@ -1,4 +1,7 @@
+import logging
+
 from vault_management_context.application.commands import UnlockVaultCommand
+
 from vault_management_context.domain.exceptions import (
     VaultNotSetupException,
     ShareReconstructionError,
@@ -15,6 +18,8 @@ from vault_management_context.application.gateways import (
 from vault_management_context.application.services import KeySessionManager
 from vault_management_context.domain.events import VaultUnlockedEvent
 from shared_kernel.application.gateways import DomainEventPublisher
+
+logger = logging.getLogger(__name__)
 
 
 class UnlockVaultUseCase:
@@ -55,6 +60,7 @@ class UnlockVaultUseCase:
             )
 
             self._share_repository.clear()
+            logger.info("Vault unlocked")
             event = VaultUnlockedEvent()
             self._event_publisher.publish(event)
             self._vault_event_repository.append_event(

--- a/server/src/vault_management_context/application/use_cases/unlock_vault_use_case.py
+++ b/server/src/vault_management_context/application/use_cases/unlock_vault_use_case.py
@@ -10,6 +10,7 @@ from vault_management_context.application.gateways import (
     EncryptionGateway,
     VaultSessionGateway,
     ShareRepository,
+    VaultEventRepository,
 )
 from vault_management_context.application.services import KeySessionManager
 from vault_management_context.domain.events import VaultUnlockedEvent
@@ -25,6 +26,7 @@ class UnlockVaultUseCase:
         vault_session_gateway: VaultSessionGateway,
         share_repository: ShareRepository,
         event_publisher: DomainEventPublisher,
+        vault_event_repository: VaultEventRepository,
     ):
         self._vault_repository = vault_repository
         self._shamir_gateway = shamir_gateway
@@ -32,6 +34,7 @@ class UnlockVaultUseCase:
         self._vault_session_gateway = vault_session_gateway
         self._share_repository = share_repository
         self._event_publisher = event_publisher
+        self._vault_event_repository = vault_event_repository
 
     def execute(self, command: UnlockVaultCommand) -> None:
         vault = self._vault_repository.get()
@@ -52,7 +55,15 @@ class UnlockVaultUseCase:
             )
 
             self._share_repository.clear()
-            self._event_publisher.publish(VaultUnlockedEvent())
+            event = VaultUnlockedEvent()
+            self._event_publisher.publish(event)
+            self._vault_event_repository.append_event(
+                event_id=event.event_id,
+                event_type=type(event).__name__,
+                occurred_on=event.occurred_on,
+                actor_user_id=None,
+                event_data={},
+            )
         except VaultUnlockedError as e:
             raise e
         except Exception as e:

--- a/server/tests/identity_access_management_context/unit/conftest.py
+++ b/server/tests/identity_access_management_context/unit/conftest.py
@@ -17,6 +17,7 @@ from .fakes import (
     FakeGroupRepository,
     FakeGroupMemberRepository,
     FakeGroupUsageGateway,
+    FakeIamEventRepository,
 )
 
 
@@ -78,6 +79,11 @@ def group_member_repository():
 @pytest.fixture
 def group_usage_gateway():
     return FakeGroupUsageGateway()
+
+
+@pytest.fixture
+def iam_event_repository():
+    return FakeIamEventRepository()
 
 
 @pytest.fixture

--- a/server/tests/identity_access_management_context/unit/fakes/__init__.py
+++ b/server/tests/identity_access_management_context/unit/fakes/__init__.py
@@ -10,6 +10,7 @@ from .fake_user_repository import FakeUserRepository
 from .fake_sso_user_repository import FakeSsoUserRepository
 from .fake_sso_encryption_gateway import FakeSsoEncryptionGateway
 from .fake_group_usage_gateway import FakeGroupUsageGateway
+from .fake_iam_event_repository import FakeIamEventRepository
 
 __all__ = [
     "FakeTokenGateway",
@@ -24,4 +25,5 @@ __all__ = [
     "FakeGroupUsageGateway",
     "FakeTimeGateway",
     "FakeUserRepository",
+    "FakeIamEventRepository",
 ]

--- a/server/tests/identity_access_management_context/unit/fakes/fake_iam_event_repository.py
+++ b/server/tests/identity_access_management_context/unit/fakes/fake_iam_event_repository.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+
+class FakeIamEventRepository:
+    """Fake implementation of IamEventRepository for testing"""
+
+    def __init__(self):
+        self.events: list[dict[str, Any]] = []
+
+    def append_event(
+        self,
+        event_id: UUID,
+        event_type: str,
+        occurred_on: datetime,
+        actor_user_id: UUID | None,
+        event_data: dict,
+    ) -> None:
+        """Append an IAM event to storage"""
+        self.events.append(
+            {
+                "event_id": event_id,
+                "event_type": event_type,
+                "occurred_on": occurred_on,
+                "actor_user_id": actor_user_id,
+                "event_data": event_data,
+            }
+        )

--- a/server/tests/identity_access_management_context/unit/use_cases/test_add_owner_to_group_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_add_owner_to_group_use_case.py
@@ -26,12 +26,14 @@ def use_case(
     group_repository: FakeGroupRepository,
     group_member_repository: FakeGroupMemberRepository,
     event_publisher,
+    iam_event_repository,
 ):
     return AddOwnerToGroupUseCase(
         user_repository=user_repository,
         group_repository=group_repository,
         group_member_repository=group_member_repository,
         event_publisher=event_publisher,
+        iam_event_repository=iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_add_user_to_group_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_add_user_to_group_use_case.py
@@ -25,12 +25,14 @@ def use_case(
     group_repository: FakeGroupRepository,
     group_member_repository: FakeGroupMemberRepository,
     event_publisher,
+    iam_event_repository,
 ):
     return AddUserToGroupUseCase(
         user_repository=user_repository,
         group_repository=group_repository,
         group_member_repository=group_member_repository,
         event_publisher=event_publisher,
+        iam_event_repository=iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_admin_login_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_admin_login_use_case.py
@@ -27,6 +27,7 @@ def use_case(
     token_gateway: FakeTokenGateway,
     time_provider: FakeTimeGateway,
     event_publisher,
+    iam_event_repository,
 ):
     return AdminLoginUseCase(
         user_password_repository,
@@ -34,6 +35,7 @@ def use_case(
         token_gateway,
         time_provider,
         event_publisher,
+        iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_configure_sso_provider_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_configure_sso_provider_use_case.py
@@ -36,10 +36,11 @@ def use_case(
     sso_configuration_repository: FakeSsoConfigurationRepository,
     sso_encryption_gateway: FakeSsoEncryptionGateway,
     event_publisher,
+    iam_event_repository,
 ):
     """Use case configured for tests."""
     return ConfigureSsoProviderUseCase(
-        sso_gateway, sso_configuration_repository, sso_encryption_gateway, event_publisher
+        sso_gateway, sso_configuration_repository, sso_encryption_gateway, event_publisher, iam_event_repository
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_create_group_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_create_group_use_case.py
@@ -23,12 +23,14 @@ def use_case(
     group_repository: FakeGroupRepository,
     group_member_repository: FakeGroupMemberRepository,
     event_publisher,
+    iam_event_repository,
 ):
     return CreateGroupUseCase(
         user_repository=user_repository,
         group_repository=group_repository,
         group_member_repository=group_member_repository,
         event_publisher=event_publisher,
+        iam_event_repository=iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_create_user_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_create_user_use_case.py
@@ -28,6 +28,7 @@ def use_case(
     group_member_repository: FakeGroupMemberRepository,
     password_hashing_gateway: FakePasswordHashingGateway,
     event_publisher,
+    iam_event_repository,
 ):
     return CreateUserUseCase(
         user_repository,
@@ -36,6 +37,7 @@ def use_case(
         group_member_repository,
         password_hashing_gateway,
         event_publisher,
+        iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_delete_group_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_delete_group_use_case.py
@@ -27,12 +27,14 @@ def use_case(
     group_member_repository: GroupMemberRepository,
     group_usage_gateway: GroupUsageGateway,
     event_publisher,
+    iam_event_repository,
 ):
     return DeleteGroupUseCase(
         group_repository=group_repository,
         group_member_repository=group_member_repository,
         group_usage_gateway=group_usage_gateway,
         event_publisher=event_publisher,
+        iam_event_repository=iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_delete_user_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_delete_user_use_case.py
@@ -21,12 +21,14 @@ def use_case(
     group_repository: FakeGroupRepository,
     group_member_repository: FakeGroupMemberRepository,
     domain_event_publisher: FakeDomainEventPublisher,
+    iam_event_repository,
 ):
     return DeleteUserUseCase(
         user_repository,
         group_repository,
         group_member_repository,
         domain_event_publisher,
+        iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_promote_admin_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_promote_admin_use_case.py
@@ -16,8 +16,8 @@ from shared_kernel.adapters.primary.exceptions import NotAdminError
 
 
 @pytest.fixture
-def use_case(user_repository: UserRepository, event_publisher):
-    return PromoteAdminUseCase(user_repository, event_publisher)
+def use_case(user_repository: UserRepository, event_publisher, iam_event_repository):
+    return PromoteAdminUseCase(user_repository, event_publisher, iam_event_repository)
 
 
 def test_given_admin_user_and_non_admin_target_when_promoting_should_add_admin_role(

--- a/server/tests/identity_access_management_context/unit/use_cases/test_register_admin_with_password_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_register_admin_with_password_use_case.py
@@ -29,6 +29,7 @@ def use_case(
     group_repository: FakeGroupRepository,
     group_member_repository: FakeGroupMemberRepository,
     event_publisher,
+    iam_event_repository,
 ):
     return RegisterAdminWithPasswordUseCase(
         user_password_repository,
@@ -37,6 +38,7 @@ def use_case(
         group_repository,
         group_member_repository,
         event_publisher,
+        iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_remove_user_from_group_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_remove_user_from_group_use_case.py
@@ -26,12 +26,14 @@ def use_case(
     group_repository: FakeGroupRepository,
     group_member_repository: FakeGroupMemberRepository,
     event_publisher,
+    iam_event_repository,
 ):
     return RemoveUserFromGroupUseCase(
         user_repository=user_repository,
         group_repository=group_repository,
         group_member_repository=group_member_repository,
         event_publisher=event_publisher,
+        iam_event_repository=iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_sso_login_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_sso_login_use_case.py
@@ -43,6 +43,7 @@ def use_case(
     sso_configuration_repository: FakeSsoConfigurationRepository,
     sso_encryption_gateway: FakeSsoEncryptionGateway,
     event_publisher,
+    iam_event_repository,
 ):
     return SsoLoginUseCase(
         sso_gateway=sso_gateway,
@@ -56,6 +57,7 @@ def use_case(
         sso_configuration_repository=sso_configuration_repository,
         sso_encryption_gateway=sso_encryption_gateway,
         event_publisher=event_publisher,
+        iam_event_repository=iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_update_group_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_update_group_use_case.py
@@ -30,11 +30,13 @@ def use_case(
     group_repository: GroupRepository,
     group_member_repository: GroupMemberRepository,
     event_publisher,
+    iam_event_repository,
 ):
     return UpdateGroupUseCase(
         group_repository=group_repository,
         group_member_repository=group_member_repository,
         event_publisher=event_publisher,
+        iam_event_repository=iam_event_repository,
     )
 
 

--- a/server/tests/identity_access_management_context/unit/use_cases/test_update_user_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_update_user_use_case.py
@@ -13,8 +13,9 @@ from ..fakes import FakeUserRepository
 def use_case(
     user_repository: FakeUserRepository,
     event_publisher,
+    iam_event_repository,
 ):
-    return UpdateUserUseCase(user_repository, event_publisher)
+    return UpdateUserUseCase(user_repository, event_publisher, iam_event_repository)
 
 
 def test_given_valid_update_data_when_updating_user_should_persist_changes(

--- a/server/tests/vault_management_context/unit/conftest.py
+++ b/server/tests/vault_management_context/unit/conftest.py
@@ -7,6 +7,7 @@ from .fakes import (
     FakeEncryptionGateway,
     FakeVaultSessionGateway,
     FakeShareRepository,
+    FakeVaultEventRepository,
 )
 
 
@@ -33,6 +34,11 @@ def vault_session_gateway():
 @pytest.fixture()
 def share_repository():
     return FakeShareRepository()
+
+
+@pytest.fixture()
+def vault_event_repository():
+    return FakeVaultEventRepository()
 
 
 @pytest.fixture()

--- a/server/tests/vault_management_context/unit/fakes/__init__.py
+++ b/server/tests/vault_management_context/unit/fakes/__init__.py
@@ -3,6 +3,7 @@ from .fake_shamir_gateway import FakeShamirGateway
 from .fake_vault_repository import FakeVaultRepository
 from .fake_vault_session_gateway import FakeVaultSessionGateway
 from .fake_share_repository import FakeShareRepository
+from .fake_vault_event_repository import FakeVaultEventRepository
 
 __all__ = [
     "FakeEncryptionGateway",
@@ -10,4 +11,5 @@ __all__ = [
     "FakeVaultRepository",
     "FakeVaultSessionGateway",
     "FakeShareRepository",
+    "FakeVaultEventRepository",
 ]

--- a/server/tests/vault_management_context/unit/fakes/fake_vault_event_repository.py
+++ b/server/tests/vault_management_context/unit/fakes/fake_vault_event_repository.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+
+class FakeVaultEventRepository:
+    """Fake implementation of VaultEventRepository for testing"""
+
+    def __init__(self):
+        self.events: list[dict[str, Any]] = []
+
+    def append_event(
+        self,
+        event_id: UUID,
+        event_type: str,
+        occurred_on: datetime,
+        actor_user_id: UUID | None,
+        event_data: dict,
+    ) -> None:
+        """Append a vault event to storage"""
+        self.events.append(
+            {
+                "event_id": event_id,
+                "event_type": event_type,
+                "occurred_on": occurred_on,
+                "actor_user_id": actor_user_id,
+                "event_data": event_data,
+            }
+        )

--- a/server/tests/vault_management_context/unit/use_cases/test_create_vault_use_case.py
+++ b/server/tests/vault_management_context/unit/use_cases/test_create_vault_use_case.py
@@ -31,9 +31,10 @@ def use_case(
     encryption_gateway: FakeEncryptionGateway,
     vault_session_gateway: FakeVaultSessionGateway,
     event_publisher,
+    vault_event_repository,
 ):
     return CreateVaultUseCase(
-        vault_repository, shamir_gateway, encryption_gateway, vault_session_gateway, event_publisher
+        vault_repository, shamir_gateway, encryption_gateway, vault_session_gateway, event_publisher, vault_event_repository
     )
 
 

--- a/server/tests/vault_management_context/unit/use_cases/test_lock_vault_use_case.py
+++ b/server/tests/vault_management_context/unit/use_cases/test_lock_vault_use_case.py
@@ -21,8 +21,9 @@ def use_case(
     vault_repository: FakeVaultRepository,
     vault_session_gateway: FakeVaultSessionGateway,
     event_publisher,
+    vault_event_repository,
 ):
-    return LockVaultUseCase(vault_repository, vault_session_gateway, event_publisher)
+    return LockVaultUseCase(vault_repository, vault_session_gateway, event_publisher, vault_event_repository)
 
 
 def test_given_unlocked_vault_when_locking_vault_should_clear_session_key(

--- a/server/tests/vault_management_context/unit/use_cases/test_unlock_vault_use_case.py
+++ b/server/tests/vault_management_context/unit/use_cases/test_unlock_vault_use_case.py
@@ -31,6 +31,7 @@ def use_case(
     vault_session_gateway: FakeVaultSessionGateway,
     share_repository: FakeShareRepository,
     event_publisher,
+    vault_event_repository,
 ):
     return UnlockVaultUseCase(
         vault_repository,
@@ -39,6 +40,7 @@ def use_case(
         vault_session_gateway,
         share_repository,
         event_publisher,
+        vault_event_repository,
     )
 
 


### PR DESCRIPTION
## Summary

- Add `iam_events` and `vault_events` PostgreSQL tables with Alembic migration, ORM models, SQL repositories, and gateway protocols
- Wire event repositories into all IAM use cases (14) and vault use cases (3) so every domain event is now persisted to the database
- Add targeted application logging: failed login attempts (WARNING), vault create/lock/unlock (INFO), slow HTTP requests >500ms (WARNING), and app startup context (db type + base URL)
- Fix logging setup to use `force=True` in basicConfig to override uvicorn handlers, and add a centralized 500 error handler
- Fix post-migration logging: alembic's `fileConfig` uses `disable_existing_loggers=True` by default, silencing all application logs after migration. Fixed by re-calling `configure_logging()` after `run_migrations()` and re-enabling all registered loggers
- Add `FakeIamEventRepository` and `FakeVaultEventRepository` test fakes; update all affected use case fixtures (13 IAM + 3 vault) — 159 tests passing

## Test plan

- [x] Run `alembic upgrade head` and verify `iam_events` and `vault_events` tables are created
- [x] Create a user, log in and verify rows appear in `iam_events`
- [x] Create/lock/unlock the vault and verify rows appear in `vault_events`
- [x] Trigger a failed login and verify a `WARNING` log line appears
- [x] Lock/unlock the vault and verify `INFO` log lines appear
- [x] Trigger a slow endpoint and verify the `WARNING` threshold log appears (mechanism verified — not triggered naturally on dev hardware where bcrypt takes ~360ms < 500ms threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)