### PR TITLE
feat: filter uvicorn access logs for successful health check requests

### DIFF
--- a/server/src/main.py
+++ b/server/src/main.py
@@ -13,6 +13,15 @@ from alembic import command
 
 logger = logging.getLogger(__name__)
 
+
+class _HealthCheckFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.getMessage()
+        return not ("GET /api/health" in msg and "200 OK" in msg)
+
+
+logging.getLogger("uvicorn.access").addFilter(_HealthCheckFilter())
+
 from config import (
     get_database_url,
     get_jwt_secret_key,

--- a/server/tests/test_health_check_filter.py
+++ b/server/tests/test_health_check_filter.py
@@ -1,0 +1,41 @@
+import logging
+import pytest
+from main import _HealthCheckFilter
+
+
+@pytest.fixture
+def filter_instance():
+    return _HealthCheckFilter()
+
+
+def make_record(message: str) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+    return record
+
+
+def test_health_200_is_filtered(filter_instance):
+    """Successful health check probes must not appear in logs."""
+    record = make_record('100.64.7.58:57990 - "GET /api/health HTTP/1.1" 200 OK')
+    assert filter_instance.filter(record) is False
+
+
+def test_health_503_is_not_filtered(filter_instance):
+    """Failed health checks (DB down) must remain visible in logs."""
+    record = make_record(
+        '100.64.7.58:57990 - "GET /api/health HTTP/1.1" 503 Service Unavailable'
+    )
+    assert filter_instance.filter(record) is True
+
+
+def test_other_routes_are_not_filtered(filter_instance):
+    """Business endpoint logs must not be affected by the filter."""
+    record = make_record('100.64.7.208:35250 - "GET /api/passwords/list HTTP/1.1" 200 OK')
+    assert filter_instance.filter(record) is True


### PR DESCRIPTION
## Summary

- Add `_HealthCheckFilter` to suppress `GET /api/health 200 OK` entries from uvicorn access logs
- Kubernetes liveness/readiness/startup probes generate ~24 req/min, flooding logs with noise
- Errors (4xx/5xx) on `/api/health` are **not** filtered and remain visible
- Add unit tests covering all three filter behaviors

## Test plan

- [x] `GET /api/health 200 OK` no longer appears in logs (`test_health_200_is_filtered`)
- [x] `GET /api/health 503` remains visible in logs (`test_health_503_is_not_filtered`)
- [x] Other business routes are unaffected (`test_other_routes_are_not_filtered`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)