### PR TITLE
fix: correct health check filter to match uvicorn log format

### DIFF
--- a/server/src/main.py
+++ b/server/src/main.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class _HealthCheckFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         msg = record.getMessage()
-        return not ("GET /api/health" in msg and "200 OK" in msg)
+        return not ("GET /api/health" in msg and '" 200' in msg)
 
 
 logging.getLogger("uvicorn.access").addFilter(_HealthCheckFilter())

--- a/server/tests/test_health_check_filter.py
+++ b/server/tests/test_health_check_filter.py
@@ -8,14 +8,15 @@ def filter_instance():
     return _HealthCheckFilter()
 
 
-def make_record(message: str) -> logging.LogRecord:
+def make_uvicorn_record(client: str, method: str, path: str, status: int) -> logging.LogRecord:
+    """Build a log record matching uvicorn's actual access log format."""
     record = logging.LogRecord(
         name="uvicorn.access",
         level=logging.INFO,
         pathname="",
         lineno=0,
-        msg=message,
-        args=(),
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=(client, method, path, "1.1", status),
         exc_info=None,
     )
     return record
@@ -23,19 +24,17 @@ def make_record(message: str) -> logging.LogRecord:
 
 def test_health_200_is_filtered(filter_instance):
     """Successful health check probes must not appear in logs."""
-    record = make_record('100.64.7.58:57990 - "GET /api/health HTTP/1.1" 200 OK')
+    record = make_uvicorn_record("100.64.7.58:57990", "GET", "/api/health", 200)
     assert filter_instance.filter(record) is False
 
 
 def test_health_503_is_not_filtered(filter_instance):
     """Failed health checks (DB down) must remain visible in logs."""
-    record = make_record(
-        '100.64.7.58:57990 - "GET /api/health HTTP/1.1" 503 Service Unavailable'
-    )
+    record = make_uvicorn_record("100.64.7.58:57990", "GET", "/api/health", 503)
     assert filter_instance.filter(record) is True
 
 
 def test_other_routes_are_not_filtered(filter_instance):
     """Business endpoint logs must not be affected by the filter."""
-    record = make_record('100.64.7.208:35250 - "GET /api/passwords/list HTTP/1.1" 200 OK')
+    record = make_uvicorn_record("100.64.7.208:35250", "GET", "/api/passwords/list", 200)
     assert filter_instance.filter(record) is True


### PR DESCRIPTION
## Summary

- Fix `_HealthCheckFilter` that was silently broken in production
- Root cause: uvicorn uses `%d` for the status code, so `getMessage()` returns `"200"` not `"200 OK"` — the `OK` text is added by the formatter, not the message itself
- The filter condition `"200 OK" in msg` never matched, so all `/api/health` requests were still logged
- Fix: check for `'" 200'` (closing quote of HTTP version + status code) which matches uvicorn's actual output
- Update tests to use uvicorn's real log record format (msg + args tuple) instead of a pre-formatted string

## Test plan

- [x] `GET /api/health 200` is now correctly filtered (`test_health_200_is_filtered`)
- [x] `GET /api/health 503` remains visible (`test_health_503_is_not_filtered`)
- [x] Other business routes are unaffected (`test_other_routes_are_not_filtered`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)