### PR TITLE
feat(monitoring): add structured JSON logging for Loki ingestion

### DIFF
--- a/server/src/logging_config.py
+++ b/server/src/logging_config.py
@@ -1,0 +1,90 @@
+"""JSON structured logging configuration for Loki ingestion.
+
+Replaces all uvicorn and application log handlers with a JSON formatter so that
+Loki can parse and index logs by field (level, logger, trace_id, ...) using LogQL.
+
+Usage: call configure_logging() once at module import time in main.py, before
+any logger is used.
+"""
+
+import datetime
+import json
+import logging
+
+
+class _JsonFormatter(logging.Formatter):
+    """Emit each log record as a single-line JSON object."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        doc: dict = {
+            "timestamp": datetime.datetime.fromtimestamp(
+                record.created, tz=datetime.timezone.utc
+            ).isoformat(timespec="milliseconds"),
+            "level": record.levelname.lower(),
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        # Preserve extra fields injected via logger.info("...", extra={...})
+        for key, value in record.__dict__.items():
+            if key not in _STANDARD_LOG_RECORD_ATTRS and not key.startswith("_"):
+                doc[key] = value
+        if record.exc_info:
+            doc["exception"] = self.formatException(record.exc_info)
+        return json.dumps(doc, ensure_ascii=False, default=str)
+
+
+# Fields that belong to the LogRecord itself — we skip them to avoid noise.
+_STANDARD_LOG_RECORD_ATTRS = frozenset(
+    {
+        "args",
+        "asctime",
+        "created",
+        "exc_info",
+        "exc_text",
+        "filename",
+        "funcName",
+        "levelname",
+        "levelno",
+        "lineno",
+        "message",
+        "module",
+        "msecs",
+        "msg",
+        "name",
+        "pathname",
+        "process",
+        "processName",
+        "relativeCreated",
+        "stack_info",
+        "thread",
+        "threadName",
+        "taskName",
+    }
+)
+
+
+def configure_logging() -> None:
+    """Switch all log handlers to JSON output.
+
+    Must be called before any logger emits records so that the formatter is in
+    place when uvicorn and FastAPI start producing output.
+    """
+    formatter = _JsonFormatter()
+
+    # Configure the root logger first so any logger that doesn't propagate
+    # through a named ancestor still gets the JSON formatter.
+    root = logging.getLogger()
+    if not root.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+        root.addHandler(handler)
+    else:
+        for handler in root.handlers:
+            handler.setFormatter(formatter)
+
+    # Explicitly reconfigure uvicorn loggers (they may have been initialised
+    # before our app module was imported by uvicorn).
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "fastapi", "sqlalchemy.engine"):
+        lgr = logging.getLogger(name)
+        for handler in lgr.handlers:
+            handler.setFormatter(formatter)

--- a/server/src/logging_config.py
+++ b/server/src/logging_config.py
@@ -1,15 +1,24 @@
 """JSON structured logging configuration for Loki ingestion.
 
-Replaces all uvicorn and application log handlers with a JSON formatter so that
-Loki can parse and index logs by field (level, logger, trace_id, ...) using LogQL.
+Replaces all log handlers with a JSON formatter so that Loki can parse and
+index logs by field (level, logger, trace_id, ...) using LogQL.
 
-Usage: call configure_logging() once at module import time in main.py, before
-any logger is used.
+Usage:
+  1. Call configure_logging() once at module import time in main.py.
+  2. Add _TraceIdMiddleware to the FastAPI app (sets trace_id per request).
+  3. Call rewire_uvicorn_logging() at lifespan startup to handle deployment
+     scenarios where uvicorn re-initialises its handlers after importing the
+     application module (e.g. --reload, gunicorn workers).
 """
 
+import contextvars
 import datetime
 import json
 import logging
+
+# Per-request trace ID — set by _TraceIdMiddleware, read by _TraceIdFilter.
+# Will be replaced by the actual OpenTelemetry trace ID in Priority 3 (Tempo).
+_trace_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("trace_id", default="-")
 
 
 class _JsonFormatter(logging.Formatter):
@@ -24,7 +33,8 @@ class _JsonFormatter(logging.Formatter):
             "logger": record.name,
             "message": record.getMessage(),
         }
-        # Preserve extra fields injected via logger.info("...", extra={...})
+        # Preserve extra fields injected via logger.info("...", extra={...}),
+        # including trace_id added by _TraceIdFilter.
         for key, value in record.__dict__.items():
             if key not in _STANDARD_LOG_RECORD_ATTRS and not key.startswith("_"):
                 doc[key] = value
@@ -33,7 +43,7 @@ class _JsonFormatter(logging.Formatter):
         return json.dumps(doc, ensure_ascii=False, default=str)
 
 
-# Fields that belong to the LogRecord itself — we skip them to avoid noise.
+# Fields that belong to the LogRecord itself — excluded to avoid noise in JSON.
 _STANDARD_LOG_RECORD_ATTRS = frozenset(
     {
         "args",
@@ -63,17 +73,33 @@ _STANDARD_LOG_RECORD_ATTRS = frozenset(
 )
 
 
+class _TraceIdFilter(logging.Filter):
+    """Inject the current request's trace_id into every log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.trace_id = _trace_id_var.get()  # type: ignore[attr-defined]
+        return True
+
+
+_CONFIGURED = False
+
+
 def configure_logging() -> None:
     """Switch all log handlers to JSON output.
 
-    Must be called before any logger emits records so that the formatter is in
-    place when uvicorn and FastAPI start producing output.
+    Idempotent — safe to call multiple times (no-op after the first call).
+    Must be called before any logger emits records.
     """
-    formatter = _JsonFormatter()
+    global _CONFIGURED
+    if _CONFIGURED:
+        return
+    _CONFIGURED = True
 
-    # Configure the root logger first so any logger that doesn't propagate
-    # through a named ancestor still gets the JSON formatter.
+    formatter = _JsonFormatter()
+    trace_filter = _TraceIdFilter()
+
     root = logging.getLogger()
+    root.setLevel(logging.INFO)
     if not root.handlers:
         handler = logging.StreamHandler()
         handler.setFormatter(formatter)
@@ -81,10 +107,27 @@ def configure_logging() -> None:
     else:
         for handler in root.handlers:
             handler.setFormatter(formatter)
+    root.addFilter(trace_filter)
 
-    # Explicitly reconfigure uvicorn loggers (they may have been initialised
-    # before our app module was imported by uvicorn).
+    # Apply to uvicorn/fastapi loggers in case they already have handlers at
+    # this point (normal production case: uvicorn sets up logging before
+    # importing the application module).
+    rewire_uvicorn_logging()
+
+
+def rewire_uvicorn_logging() -> None:
+    """Re-apply the JSON formatter and trace filter to uvicorn's own handlers.
+
+    Called from both configure_logging() and the lifespan startup to handle
+    scenarios where uvicorn re-initialises its handlers after the application
+    module is imported (e.g. --reload, gunicorn workers).
+    """
+    formatter = _JsonFormatter()
+    trace_filter = _TraceIdFilter()
+
     for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "fastapi", "sqlalchemy.engine"):
         lgr = logging.getLogger(name)
         for handler in lgr.handlers:
             handler.setFormatter(formatter)
+        if not any(isinstance(f, _TraceIdFilter) for f in lgr.filters):
+            lgr.addFilter(trace_filter)

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -11,16 +11,27 @@ from sqlalchemy.orm import sessionmaker
 from alembic.config import Config
 from alembic import command
 
+# Switch all handlers to JSON output before any logger fires.
+from logging_config import configure_logging
+configure_logging()
+
 logger = logging.getLogger(__name__)
 
 
-class _HealthCheckFilter(logging.Filter):
+class _NoiseFilter(logging.Filter):
+    """Suppress high-frequency OK responses that would flood Loki with useless entries."""
+
+    _SUPPRESSED = (
+        ("GET /api/health", '" 200'),
+        ("GET /api/metrics", '" 200'),
+    )
+
     def filter(self, record: logging.LogRecord) -> bool:
         msg = record.getMessage()
-        return not ("GET /api/health" in msg and '" 200' in msg)
+        return not any(path in msg and status in msg for path, status in self._SUPPRESSED)
 
 
-logging.getLogger("uvicorn.access").addFilter(_HealthCheckFilter())
+logging.getLogger("uvicorn.access").addFilter(_NoiseFilter())
 
 from config import (
     get_database_url,

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+import uuid
 from pathlib import Path
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
@@ -10,9 +11,10 @@ from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 from alembic.config import Config
 from alembic import command
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 # Switch all handlers to JSON output before any logger fires.
-from logging_config import configure_logging
+from logging_config import configure_logging, rewire_uvicorn_logging, _trace_id_var
 configure_logging()
 
 logger = logging.getLogger(__name__)
@@ -21,17 +23,50 @@ logger = logging.getLogger(__name__)
 class _NoiseFilter(logging.Filter):
     """Suppress high-frequency OK responses that would flood Loki with useless entries."""
 
-    _SUPPRESSED = (
-        ("GET /api/health", '" 200'),
-        ("GET /api/metrics", '" 200'),
-    )
+    _SUPPRESSED_ROUTES = frozenset({"/api/health", "/api/metrics"})
 
     def filter(self, record: logging.LogRecord) -> bool:
-        msg = record.getMessage()
-        return not any(path in msg and status in msg for path, status in self._SUPPRESSED)
+        # Parse record.args directly — uvicorn access log format is a 5-tuple:
+        # (client_addr, method, path, http_version, status_code)
+        # Using args avoids coupling to uvicorn's internal format string.
+        args = record.args
+        if (
+            isinstance(args, tuple)
+            and len(args) == 5
+            and args[1] == "GET"
+            and args[2] in self._SUPPRESSED_ROUTES
+            and args[4] == 200
+        ):
+            return False
+        return True
 
 
 logging.getLogger("uvicorn.access").addFilter(_NoiseFilter())
+
+
+class _TraceIdMiddleware:
+    """Assign a unique trace_id per request for structured log correlation.
+
+    Reads the X-Trace-Id header if present (useful for distributed tracing),
+    otherwise generates a new UUID. The trace_id is injected into every log
+    record emitted during the request via _TraceIdFilter.
+    Will be wired to the actual OpenTelemetry trace ID in Priority 3 (Tempo).
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            headers = {k.lower(): v for k, v in scope.get("headers", [])}
+            trace_id = headers.get(b"x-trace-id", b"").decode() or str(uuid.uuid4())
+            token = _trace_id_var.set(trace_id)
+            try:
+                await self.app(scope, receive, send)
+            finally:
+                _trace_id_var.reset(token)
+        else:
+            await self.app(scope, receive, send)
 
 from config import (
     get_database_url,
@@ -121,6 +156,10 @@ def _build_engine(database_url: str):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Re-apply JSON formatter to uvicorn's handlers. Uvicorn may have
+    # re-initialised its logging config after our module was imported.
+    rewire_uvicorn_logging()
+
     # Run migrations instead of create_tables
     logger.info("Starting database migrations...")
     run_migrations()
@@ -197,8 +236,10 @@ async def lifespan(app: FastAPI):
 app = FastAPI(lifespan=lifespan, root_path="/api")
 
 
-# Add CSRF protection middleware
+# _TraceIdMiddleware must be outermost so trace_id is set before any other
+# middleware or handler emits log records.
 app.add_middleware(CsrfMiddleware)
+app.add_middleware(_TraceIdMiddleware)
 
 
 @app.exception_handler(Exception)

--- a/server/tests/test_health_check_filter.py
+++ b/server/tests/test_health_check_filter.py
@@ -40,6 +40,12 @@ def test_metrics_200_is_filtered(filter_instance):
     assert filter_instance.filter(record) is False
 
 
+def test_metrics_503_is_not_filtered(filter_instance):
+    """Failed Prometheus scrapes must remain visible in logs."""
+    record = make_uvicorn_record("10.32.7.62:12345", "GET", "/api/metrics", 503)
+    assert filter_instance.filter(record) is True
+
+
 def test_other_routes_are_not_filtered(filter_instance):
     """Business endpoint logs must not be affected by the filter."""
     record = make_uvicorn_record("100.64.7.208:35250", "GET", "/api/passwords/list", 200)

--- a/server/tests/test_health_check_filter.py
+++ b/server/tests/test_health_check_filter.py
@@ -1,11 +1,11 @@
 import logging
 import pytest
-from main import _HealthCheckFilter
+from main import _NoiseFilter
 
 
 @pytest.fixture
 def filter_instance():
-    return _HealthCheckFilter()
+    return _NoiseFilter()
 
 
 def make_uvicorn_record(client: str, method: str, path: str, status: int) -> logging.LogRecord:
@@ -32,6 +32,12 @@ def test_health_503_is_not_filtered(filter_instance):
     """Failed health checks (DB down) must remain visible in logs."""
     record = make_uvicorn_record("100.64.7.58:57990", "GET", "/api/health", 503)
     assert filter_instance.filter(record) is True
+
+
+def test_metrics_200_is_filtered(filter_instance):
+    """Successful Prometheus scrapes must not appear in logs."""
+    record = make_uvicorn_record("10.32.7.62:12345", "GET", "/api/metrics", 200)
+    assert filter_instance.filter(record) is False
 
 
 def test_other_routes_are_not_filtered(filter_instance):

--- a/server/tests/test_logging_config.py
+++ b/server/tests/test_logging_config.py
@@ -1,0 +1,155 @@
+"""Tests for logging_config: _JsonFormatter, _TraceIdFilter, configure_logging."""
+
+import json
+import logging
+import sys
+
+import pytest
+
+import logging_config
+from logging_config import (
+    _JsonFormatter,
+    _TraceIdFilter,
+    _trace_id_var,
+    configure_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_configure_flag(monkeypatch):
+    """Reset the idempotency guard before each test so configure_logging() runs fresh."""
+    monkeypatch.setattr(logging_config, "_CONFIGURED", False)
+
+
+# ---------------------------------------------------------------------------
+# _JsonFormatter
+# ---------------------------------------------------------------------------
+
+class TestJsonFormatter:
+    def _record(self, msg: str = "hello", level: int = logging.INFO, **extra) -> logging.LogRecord:
+        r = logging.LogRecord("test.logger", level, "", 0, msg, (), None)
+        for k, v in extra.items():
+            setattr(r, k, v)
+        return r
+
+    def test_output_is_valid_json(self):
+        output = _JsonFormatter().format(self._record())
+        assert isinstance(json.loads(output), dict)
+
+    def test_required_fields_present(self):
+        parsed = json.loads(_JsonFormatter().format(self._record("hello world")))
+        assert parsed["message"] == "hello world"
+        assert parsed["level"] == "info"
+        assert parsed["logger"] == "test.logger"
+        assert "timestamp" in parsed
+
+    def test_extra_fields_included(self):
+        parsed = json.loads(_JsonFormatter().format(self._record(request_id="abc-123")))
+        assert parsed["request_id"] == "abc-123"
+
+    def test_standard_attrs_not_leaked(self):
+        parsed = json.loads(_JsonFormatter().format(self._record()))
+        for attr in ("msg", "args", "lineno", "pathname", "funcName", "levelno"):
+            assert attr not in parsed
+
+    def test_exception_field_populated(self):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            exc_info = sys.exc_info()
+        r = self._record()
+        r.exc_info = exc_info
+        parsed = json.loads(_JsonFormatter().format(r))
+        assert "exception" in parsed
+        assert "ValueError: boom" in parsed["exception"]
+
+    def test_non_serializable_extra_uses_str_fallback(self):
+        r = self._record()
+        r.obj = object()  # not JSON-serializable
+        output = _JsonFormatter().format(r)  # must not raise
+        assert isinstance(json.loads(output), dict)
+
+
+# ---------------------------------------------------------------------------
+# _TraceIdFilter
+# ---------------------------------------------------------------------------
+
+class TestTraceIdFilter:
+    def test_injects_current_trace_id(self):
+        token = _trace_id_var.set("req-abc-123")
+        try:
+            r = logging.LogRecord("x", logging.INFO, "", 0, "msg", (), None)
+            _TraceIdFilter().filter(r)
+            assert r.trace_id == "req-abc-123"
+        finally:
+            _trace_id_var.reset(token)
+
+    def test_default_is_dash_outside_request(self):
+        r = logging.LogRecord("x", logging.INFO, "", 0, "msg", (), None)
+        _TraceIdFilter().filter(r)
+        assert r.trace_id == "-"
+
+    def test_filter_always_returns_true(self):
+        r = logging.LogRecord("x", logging.INFO, "", 0, "msg", (), None)
+        assert _TraceIdFilter().filter(r) is True
+
+
+# ---------------------------------------------------------------------------
+# configure_logging
+# ---------------------------------------------------------------------------
+
+class TestConfigureLogging:
+    def test_root_handler_uses_json_formatter(self):
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_level = root.level
+        try:
+            root.handlers.clear()
+            configure_logging()
+            assert any(isinstance(h.formatter, _JsonFormatter) for h in root.handlers)
+        finally:
+            root.handlers[:] = original_handlers
+            root.setLevel(original_level)
+
+    def test_root_level_set_to_info(self):
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_level = root.level
+        try:
+            root.handlers.clear()
+            root.setLevel(logging.WARNING)
+            configure_logging()
+            assert root.level == logging.INFO
+        finally:
+            root.handlers[:] = original_handlers
+            root.setLevel(original_level)
+
+    def test_idempotent_no_duplicate_handlers(self):
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_level = root.level
+        try:
+            root.handlers.clear()
+            configure_logging()
+            count_after_first = len(root.handlers)
+            # Second call: _CONFIGURED is True — must be a no-op.
+            configure_logging()
+            assert len(root.handlers) == count_after_first
+        finally:
+            root.handlers[:] = original_handlers
+            root.setLevel(original_level)
+
+    def test_trace_id_filter_added_to_root(self):
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+        original_filters = root.filters[:]
+        original_level = root.level
+        try:
+            root.handlers.clear()
+            root.filters.clear()
+            configure_logging()
+            assert any(isinstance(f, _TraceIdFilter) for f in root.filters)
+        finally:
+            root.handlers[:] = original_handlers
+            root.filters[:] = original_filters
+            root.setLevel(original_level)


### PR DESCRIPTION
## Summary

- Replace plain-text logs with structured JSON output on all uvicorn and application loggers
- Suppress high-frequency scrape/health-check noise (`/api/metrics`, `/api/health`) from the Loki stream
- Pre-wire `trace_id` field in the log format for correlation with Tempo traces (Priority 3)

## Changes

### `server/src/logging_config.py` (new)
`_JsonFormatter` emits each log record as a single-line JSON object with consistent fields:
`{ "timestamp", "level", "logger", "message", ...extra }`

`configure_logging()` applies the formatter to all existing handlers (root, uvicorn, fastapi, sqlalchemy) at startup.

### `server/src/main.py`
- Call `configure_logging()` before any logger fires
- Extend the access-log filter (`_NoiseFilter`) to also suppress `GET /api/metrics 200`

## Kubernetes resources

Loki, Alloy, ServiceMonitor, and PrometheusRules are managed in [soma-smart/dep-install-tools-on-k8s](https://github.com/soma-smart/dep-install-tools-on-k8s) (branch: `scw`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)