### PR TITLE
fix(monitoring): skip insecure OTLP warnings for cluster-internal endpoints

### DIFF
--- a/server/src/monitoring.py
+++ b/server/src/monitoring.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
 # Optional OpenTelemetry SDK — installed via the [monitoring] dependency group.
 try:
@@ -236,15 +237,20 @@ def _is_internal_endpoint(endpoint: str) -> bool:
     """Return True if the endpoint targets a cluster-internal or loopback host.
 
     Internal endpoints (localhost, single-label hostnames, *.svc, *.svc.cluster.local,
-    *.local, loopback IPs) do not require TLS or auth tokens — traffic stays within
-    the cluster network and is never exposed to the internet.
+    *.local, loopback addresses 127.0.0.1 and ::1) do not require TLS or auth tokens —
+    traffic stays within the cluster network and is never exposed to the internet.
+
+    Note: *.local also matches corporate TLDs (e.g. collector.corp.local); this is an
+    accepted trade-off — such environments are still considered trusted networks.
+
+    An empty or unparseable URL (no extractable hostname) is treated as internal to
+    avoid spurious warnings when the endpoint is not configured.
     """
-    from urllib.parse import urlparse
     host = urlparse(endpoint).hostname or ""
     return (
         host in ("localhost", "127.0.0.1", "::1")
-        or not host
-        or "." not in host  # single-label: alloy, otel-collector, …
+        or not host  # empty or unparseable URL — no real destination to warn about
+        or "." not in host  # Kubernetes in-namespace service name (e.g. alloy, otel-collector)
         or host.endswith(".svc")
         or host.endswith(".svc.cluster.local")
         or host.endswith(".local")
@@ -254,11 +260,20 @@ def _is_internal_endpoint(endpoint: str) -> bool:
 def _warn_insecure_otlp(endpoint: str) -> None:
     """Emit warnings when the OTLP transport is insecure or unauthenticated.
 
-    Skipped for cluster-internal endpoints (loopback, single-label hostnames,
-    *.svc, *.svc.cluster.local, *.local) where plain HTTP and no auth token
-    are acceptable because traffic never leaves the cluster network.
+    Two warnings may be emitted:
+    - Plain HTTP transport (endpoint starts with http://)
+    - Missing OTEL_EXPORTER_OTLP_HEADERS (no auth token configured)
+
+    Both warnings are skipped for cluster-internal endpoints (loopback addresses
+    127.0.0.1 and ::1, single-label hostnames, *.svc, *.svc.cluster.local, *.local)
+    where plain HTTP and no auth token are acceptable because traffic never leaves
+    the cluster network.
     """
     if _is_internal_endpoint(endpoint):
+        logger.debug(
+            "OTLP endpoint %r classified as cluster-internal — skipping insecure transport warnings.",
+            endpoint,
+        )
         return
     if endpoint.startswith("http://"):
         logger.warning(

--- a/server/src/monitoring.py
+++ b/server/src/monitoring.py
@@ -232,8 +232,34 @@ def _configure_otel(app) -> tuple:
     return tracer_provider, meter_provider
 
 
+def _is_internal_endpoint(endpoint: str) -> bool:
+    """Return True if the endpoint targets a cluster-internal or loopback host.
+
+    Internal endpoints (localhost, single-label hostnames, *.svc, *.svc.cluster.local,
+    *.local, loopback IPs) do not require TLS or auth tokens — traffic stays within
+    the cluster network and is never exposed to the internet.
+    """
+    from urllib.parse import urlparse
+    host = urlparse(endpoint).hostname or ""
+    return (
+        host in ("localhost", "127.0.0.1", "::1")
+        or not host
+        or "." not in host  # single-label: alloy, otel-collector, …
+        or host.endswith(".svc")
+        or host.endswith(".svc.cluster.local")
+        or host.endswith(".local")
+    )
+
+
 def _warn_insecure_otlp(endpoint: str) -> None:
-    """Emit warnings when the OTLP transport is insecure or unauthenticated."""
+    """Emit warnings when the OTLP transport is insecure or unauthenticated.
+
+    Skipped for cluster-internal endpoints (loopback, single-label hostnames,
+    *.svc, *.svc.cluster.local, *.local) where plain HTTP and no auth token
+    are acceptable because traffic never leaves the cluster network.
+    """
+    if _is_internal_endpoint(endpoint):
+        return
     if endpoint.startswith("http://"):
         logger.warning(
             "OTLP endpoint uses plain HTTP — telemetry may be intercepted in transit. "

--- a/server/tests/test_monitoring.py
+++ b/server/tests/test_monitoring.py
@@ -10,7 +10,7 @@ import opentelemetry.trace as otel_trace
 from opentelemetry.trace import NonRecordingSpan, INVALID_SPAN_CONTEXT
 from opentelemetry.trace import StatusCode
 
-from monitoring import JsonFormatter, setup_monitoring, _UvicornAccessFilter, setup_logging, _parse_resource_attributes
+from monitoring import JsonFormatter, setup_monitoring, _UvicornAccessFilter, setup_logging, _parse_resource_attributes, _is_internal_endpoint, _warn_insecure_otlp
 
 
 @pytest.fixture
@@ -472,6 +472,69 @@ def test_build_sampler_out_of_range_falls_back_to_parentbased(caplog):
 
     mock_parent_based.assert_called_once_with(mock_always_on)
     assert "OTEL_TRACES_SAMPLER_ARG" in caplog.text
+
+
+# --- _is_internal_endpoint ---
+
+
+@pytest.mark.parametrize("endpoint", [
+    "http://alloy:4318",
+    "http://otel-collector:4318",
+    "http://localhost:4318",
+    "http://127.0.0.1:4318",
+    "http://alloy.monitoring.svc:4318",
+    "http://alloy.monitoring.svc.cluster.local:4318",
+    "http://collector.local:4318",
+])
+def test_is_internal_endpoint_returns_true_for_internal(endpoint):
+    assert _is_internal_endpoint(endpoint) is True
+
+
+@pytest.mark.parametrize("endpoint", [
+    "http://otel.example.com:4318",
+    "https://otel.example.com:4318",
+    "http://collector.mycompany.io:4318",
+])
+def test_is_internal_endpoint_returns_false_for_external(endpoint):
+    assert _is_internal_endpoint(endpoint) is False
+
+
+# --- _warn_insecure_otlp ---
+
+
+def test_warn_insecure_otlp_no_warning_for_internal_http(caplog):
+    """Internal HTTP endpoints must not trigger any warning."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("OTEL_EXPORTER_OTLP_HEADERS", None)
+        with caplog.at_level(logging.WARNING, logger="monitoring"):
+            _warn_insecure_otlp("http://alloy:4318")
+    assert caplog.text == ""
+
+
+def test_warn_insecure_otlp_warns_http_for_external(caplog):
+    """External HTTP endpoint must trigger the plain-HTTP warning."""
+    env = {k: v for k, v in os.environ.items() if k != "OTEL_EXPORTER_OTLP_HEADERS"}
+    with patch.dict(os.environ, env, clear=True):
+        with caplog.at_level(logging.WARNING, logger="monitoring"):
+            _warn_insecure_otlp("http://otel.example.com:4318")
+    assert "plain HTTP" in caplog.text
+
+
+def test_warn_insecure_otlp_warns_no_auth_for_external(caplog):
+    """External endpoint without headers must trigger the auth warning."""
+    env = {k: v for k, v in os.environ.items() if k != "OTEL_EXPORTER_OTLP_HEADERS"}
+    with patch.dict(os.environ, env, clear=True):
+        with caplog.at_level(logging.WARNING, logger="monitoring"):
+            _warn_insecure_otlp("http://otel.example.com:4318")
+    assert "OTEL_EXPORTER_OTLP_HEADERS" in caplog.text
+
+
+def test_warn_insecure_otlp_no_warning_for_external_https_with_auth(caplog):
+    """External HTTPS endpoint with auth headers must not trigger any warning."""
+    with patch.dict(os.environ, {"OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer token123"}):
+        with caplog.at_level(logging.WARNING, logger="monitoring"):
+            _warn_insecure_otlp("https://otel.example.com:4318")
+    assert caplog.text == ""
 
 
 # --- _configure_otel test ---

--- a/server/tests/test_monitoring.py
+++ b/server/tests/test_monitoring.py
@@ -482,9 +482,13 @@ def test_build_sampler_out_of_range_falls_back_to_parentbased(caplog):
     "http://otel-collector:4318",
     "http://localhost:4318",
     "http://127.0.0.1:4318",
+    "http://[::1]:4318",
     "http://alloy.monitoring.svc:4318",
     "http://alloy.monitoring.svc.cluster.local:4318",
     "http://collector.local:4318",
+    "",           # empty string — no endpoint configured
+    "not-a-url",  # unparseable — no hostname extractable
+    "http://",    # scheme only — no hostname
 ])
 def test_is_internal_endpoint_returns_true_for_internal(endpoint):
     assert _is_internal_endpoint(endpoint) is True
@@ -494,6 +498,7 @@ def test_is_internal_endpoint_returns_true_for_internal(endpoint):
     "http://otel.example.com:4318",
     "https://otel.example.com:4318",
     "http://collector.mycompany.io:4318",
+    "http://0.0.0.0:4318",
 ])
 def test_is_internal_endpoint_returns_false_for_external(endpoint):
     assert _is_internal_endpoint(endpoint) is False
@@ -504,8 +509,8 @@ def test_is_internal_endpoint_returns_false_for_external(endpoint):
 
 def test_warn_insecure_otlp_no_warning_for_internal_http(caplog):
     """Internal HTTP endpoints must not trigger any warning."""
-    with patch.dict(os.environ, {}, clear=False):
-        os.environ.pop("OTEL_EXPORTER_OTLP_HEADERS", None)
+    env = {k: v for k, v in os.environ.items() if k != "OTEL_EXPORTER_OTLP_HEADERS"}
+    with patch.dict(os.environ, env, clear=True):
         with caplog.at_level(logging.WARNING, logger="monitoring"):
             _warn_insecure_otlp("http://alloy:4318")
     assert caplog.text == ""
@@ -535,6 +540,16 @@ def test_warn_insecure_otlp_no_warning_for_external_https_with_auth(caplog):
         with caplog.at_level(logging.WARNING, logger="monitoring"):
             _warn_insecure_otlp("https://otel.example.com:4318")
     assert caplog.text == ""
+
+
+def test_warn_insecure_otlp_warns_no_auth_for_external_https(caplog):
+    """External HTTPS endpoint without auth headers must trigger only the auth warning."""
+    env = {k: v for k, v in os.environ.items() if k != "OTEL_EXPORTER_OTLP_HEADERS"}
+    with patch.dict(os.environ, env, clear=True):
+        with caplog.at_level(logging.WARNING, logger="monitoring"):
+            _warn_insecure_otlp("https://otel.example.com:4318")
+    assert "OTEL_EXPORTER_OTLP_HEADERS" in caplog.text
+    assert "plain HTTP" not in caplog.text
 
 
 # --- _configure_otel test ---


### PR DESCRIPTION
## Summary

- Adds `_is_internal_endpoint()` to detect loopback, single-label hostnames, `*.svc`, `*.svc.cluster.local`, and `*.local` endpoints
- `_warn_insecure_otlp()` now returns early for internal endpoints — plain HTTP and no auth token are acceptable within the cluster network
- Warnings still fire for any external endpoint (e.g. `http://otel.example.com`)

## Test plan

- [x] Internal endpoint (`http://alloy:4318`) — no warnings at startup
- [x] External HTTP endpoint (`http://otel.example.com:4318`) — both warnings appear
- [x] External HTTPS endpoint with headers set — no warnings
- [x] 60/60 unit tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)