### PR TITLE
fix(ci): make release workflow idempotent on duplicate tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,12 +73,36 @@ jobs:
             const tag = context.ref.replace('refs/tags/', '');
             const changelog = `${{ steps.changelog.outputs.changelog }}`;
 
-            await github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: tag,
-              name: `Release ${tag}`,
-              body: changelog,
-              draft: false,
-              prerelease: false
-            });
+            let existingRelease;
+            try {
+              const { data } = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: tag,
+              });
+              existingRelease = data;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
+            if (existingRelease) {
+              await github.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: existingRelease.id,
+                name: `Release ${tag}`,
+                body: changelog,
+                draft: false,
+                prerelease: false,
+              });
+            } else {
+              await github.rest.repos.createRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag_name: tag,
+                name: `Release ${tag}`,
+                body: changelog,
+                draft: false,
+                prerelease: false,
+              });
+            }


### PR DESCRIPTION
## Summary

- Replaces the bare `createRelease` call with a `getReleaseByTag` + create/update pattern
- If a release already exists for the tag → `updateRelease` (body and name are refreshed)
- If no release exists → `createRelease` as before
- Any unexpected error is still re-thrown

Fixes the `422 already_exists` failure that occurs when the workflow is re-triggered on the same tag.

## Test plan

- [x] Workflow was failing with `HttpError: Validation Failed / already_exists` on run [22727203960](https://github.com/soma-smart/le-coffre/actions/runs/22727203960)
- [ ] Push a tag twice (or re-run the workflow manually) — second run must succeed and update the existing release

🤖 Generated with [Claude Code](https://claude.com/claude-code)