### PR TITLE
Fix broken mono process tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Run Unit Tests
         if: success() || failure()
         working-directory: server/
-        run: uv run pytest -n auto
+        run: uv run pytest .
 
   back-ci-no-monitoring:
     timeout-minutes: 10
@@ -147,7 +147,7 @@ jobs:
 
       - name: Run Unit Tests
         working-directory: server/
-        run: uv run pytest -n auto
+        run: uv run pytest .
 
   openapi-sync-check:
     timeout-minutes: 10

--- a/server/README.md
+++ b/server/README.md
@@ -89,7 +89,7 @@ See [server/alembic/README.md](alembic/README.md) for migration full documentati
 ## Run the tests
 
 ```bash
-uv run pytest -n auto
+uv run pytest .
 ```
 
 Tests that require OpenTelemetry are automatically skipped if the `monitoring` group is not installed.

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+import secrets
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def env_vars():
+    os.environ["JWT_SECRET_KEY"] = secrets.token_urlsafe(32)
+    os.environ["JWT_ALGORITHM"] = "HS256"
+    # Use very high rate limits so e2e tests are not impacted
+    os.environ["RATE_LIMIT_AUTH_MAX_REQUESTS"] = "1000"
+    os.environ["RATE_LIMIT_API_MAX_REQUESTS"] = "1000"
+    yield
+    del os.environ["JWT_SECRET_KEY"]
+    del os.environ["JWT_ALGORITHM"]
+    os.environ.pop("RATE_LIMIT_AUTH_MAX_REQUESTS", None)
+    os.environ.pop("RATE_LIMIT_API_MAX_REQUESTS", None)

--- a/server/tests/e2e/conftest.py
+++ b/server/tests/e2e/conftest.py
@@ -1,5 +1,4 @@
 import os
-import secrets
 import tempfile
 from urllib.parse import parse_qs, quote, urlparse
 
@@ -82,20 +81,6 @@ class CsrfTestClient(TestClient):
 
         kwargs["headers"] = headers
         return method(*args, **kwargs)
-
-
-@pytest.fixture(scope="session")
-def env_vars():
-    os.environ["JWT_SECRET_KEY"] = secrets.token_urlsafe(32)
-    os.environ["JWT_ALGORITHM"] = "HS256"
-    # Use very high rate limits so e2e tests are not impacted
-    os.environ["RATE_LIMIT_AUTH_MAX_REQUESTS"] = "1000"
-    os.environ["RATE_LIMIT_API_MAX_REQUESTS"] = "1000"
-    yield
-    del os.environ["JWT_SECRET_KEY"]
-    del os.environ["JWT_ALGORITHM"]
-    os.environ.pop("RATE_LIMIT_AUTH_MAX_REQUESTS", None)
-    os.environ.pop("RATE_LIMIT_API_MAX_REQUESTS", None)
 
 
 @pytest.fixture(scope="session")

--- a/server/tests/test_health_check_filter.py
+++ b/server/tests/test_health_check_filter.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import secrets
 import tempfile
 import time
 from unittest.mock import MagicMock, patch
@@ -20,13 +19,17 @@ def filter_instance():
 
 
 @pytest.fixture(scope="module")
-def client():
+def database_url():
     db_fd, db_path = tempfile.mkstemp(suffix=".db")
     os.close(db_fd)
-    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
-    os.environ["JWT_SECRET_KEY"] = secrets.token_urlsafe(32)
-    os.environ["JWT_ALGORITHM"] = "HS256"
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("DATABASE_URL", f"sqlite:///{db_path}")
+        yield f"sqlite:///{db_path}"
+    os.unlink(db_path)
 
+
+@pytest.fixture(scope="module")
+def client(env_vars, database_url):
     alembic_cfg = Config("alembic.ini")
     alembic_cfg.set_main_option("script_location", "alembic")
     command.upgrade(alembic_cfg, "head")
@@ -41,11 +44,6 @@ def client():
             time.sleep(0.05)
         assert c.app.state.ready, "Background migration task did not complete in time"
         yield c
-
-    os.unlink(db_path)
-    del os.environ["DATABASE_URL"]
-    del os.environ["JWT_SECRET_KEY"]
-    del os.environ["JWT_ALGORITHM"]
 
 
 def make_uvicorn_record(client: str, method: str, path: str, status: int) -> logging.LogRecord:


### PR DESCRIPTION
# Fix broken mono process tests

## Description
This PR aim to solve the issue caused by PR #206. The tests are all successfull when they are run in multiprocess environnement (uv run pytest -n auto .), but not in a mono process environnement (uv run pytest .)

When running the full test suite (pytest tests/), a KeyError was raised during session teardown — attributed to the last test that ran, even though that test had nothing to do with the failure.

Root cause: Two fixtures were writing and deleting the same environment variables (JWT_SECRET_KEY, JWT_ALGORITHM, DATABASE_URL) without coordinating with each other:

tests/e2e/conftest.py — session-scoped env_vars and database_path fixtures set these variables at session start and deleted them at session end.
tests/test_health_check_filter.py — a module-scoped client fixture also set and unconditionally deleted the same variables during its own teardown, which ran before the session ended.
By the time the session-scoped fixtures tried to clean up, the keys had already been removed, causing a KeyError.

## Related Issues
<!-- List any related issues or tasks. Use "Fixes #<issue_number>" to automatically close the issue when the PR is merged. -->
- Fixes #

## Checklist
- [ ] I have tested the changes locally.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have ensured that my code follows the project's coding standards.

## Screenshots (if applicable)
<!-- Add screenshots to help explain the changes, if applicable. -->
