### PR TITLE
Add container image scanning and SAST to CI/CD pipelines

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -229,38 +229,3 @@ jobs:
           if [ -n "$FASTAPI_PID" ]; then
             kill $FASTAPI_PID 2>/dev/null || true
           fi
-
-  codeql:
-    name: CodeQL SAST
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [python, javascript-typescript]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: ${{ matrix.language }}
-
-      - name: Install Bun (javascript-typescript only)
-        if: matrix.language == 'javascript-typescript'
-        uses: oven-sh/setup-bun@v2
-
-      - name: Build (javascript-typescript only)
-        if: matrix.language == 'javascript-typescript'
-        working-directory: frontend/
-        run: bun install --frozen-lockfile
-
-      - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
-        with:
-          category: codeql-${{ matrix.language }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -252,8 +252,14 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      - name: Install Bun (javascript-typescript only)
+        if: matrix.language == 'javascript-typescript'
+        uses: oven-sh/setup-bun@v2
+
+      - name: Build (javascript-typescript only)
+        if: matrix.language == 'javascript-typescript'
+        working-directory: frontend/
+        run: bun install --frozen-lockfile
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   front-ci:
     timeout-minutes: 10
@@ -229,3 +234,28 @@ jobs:
           if [ -n "$FASTAPI_PID" ]; then
             kill $FASTAPI_PID 2>/dev/null || true
           fi
+
+  codeql:
+    name: CodeQL SAST
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, javascript-typescript]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: codeql-${{ matrix.language }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   front-ci:
     timeout-minutes: 10

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,10 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  actions: read
-  contents: read
-  security-events: write
 
 jobs:
   front-ci:
@@ -239,6 +235,10 @@ jobs:
     name: CodeQL SAST
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,31 +35,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push backend image
+      - name: Build backend image
         uses: docker/build-push-action@v6.17.0
         with:
           context: ./server
           file: ./server/Dockerfile
-          push: true
+          push: false
+          load: true
           platforms: linux/amd64
           tags: |
             ${{ env.REGISTRY }}/le-coffre-backend:${{ steps.set_outputs.outputs.image_tag }}
             ${{ env.REGISTRY }}/le-coffre-backend:latest
           cache-from: type=registry,ref=${{ env.REGISTRY }}/le-coffre-backend:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/le-coffre-backend:buildcache,mode=max,ignore-error=true
-
-      - name: Build and push frontend image
-        uses: docker/build-push-action@v6.17.0
-        with:
-          context: ./frontend
-          file: ./frontend/Dockerfile
-          push: true
-          platforms: linux/amd64
-          tags: |
-            ${{ env.REGISTRY }}/le-coffre-frontend:${{ steps.set_outputs.outputs.image_tag }}
-            ${{ env.REGISTRY }}/le-coffre-frontend:latest
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/le-coffre-frontend:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/le-coffre-frontend:buildcache,mode=max,ignore-error=true
 
       - name: Scan backend image (Grype)
         uses: anchore/scan-action@v7.3.1
@@ -77,6 +65,25 @@ jobs:
           sarif_file: ${{ steps.grype-backend.outputs.sarif }}
           category: container-backend
 
+      - name: Push backend image
+        run: |
+          docker push ${{ env.REGISTRY }}/le-coffre-backend:${{ steps.set_outputs.outputs.image_tag }}
+          docker push ${{ env.REGISTRY }}/le-coffre-backend:latest
+
+      - name: Build frontend image
+        uses: docker/build-push-action@v6.17.0
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: |
+            ${{ env.REGISTRY }}/le-coffre-frontend:${{ steps.set_outputs.outputs.image_tag }}
+            ${{ env.REGISTRY }}/le-coffre-frontend:latest
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/le-coffre-frontend:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/le-coffre-frontend:buildcache,mode=max,ignore-error=true
+
       - name: Scan frontend image (Grype)
         uses: anchore/scan-action@v7.3.1
         id: grype-frontend
@@ -92,6 +99,11 @@ jobs:
         with:
           sarif_file: ${{ steps.grype-frontend.outputs.sarif }}
           category: container-frontend
+
+      - name: Push frontend image
+        run: |
+          docker push ${{ env.REGISTRY }}/le-coffre-frontend:${{ steps.set_outputs.outputs.image_tag }}
+          docker push ${{ env.REGISTRY }}/le-coffre-frontend:latest
 
       - name: Generate changelog
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
 permissions:
   contents: write
   packages: write
+  security-events: write
 
 jobs:
   release:
@@ -59,6 +60,38 @@ jobs:
             ${{ env.REGISTRY }}/le-coffre-frontend:latest
           cache-from: type=registry,ref=${{ env.REGISTRY }}/le-coffre-frontend:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/le-coffre-frontend:buildcache,mode=max,ignore-error=true
+
+      - name: Scan backend image (Grype)
+        uses: anchore/scan-action@v7.3.1
+        id: grype-backend
+        with:
+          image: ${{ env.REGISTRY }}/le-coffre-backend:${{ steps.set_outputs.outputs.image_tag }}
+          fail-build: true
+          severity-cutoff: critical
+          output-format: sarif
+
+      - name: Upload backend scan results to GitHub Security
+        if: always() && steps.grype-backend.outputs.sarif != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.grype-backend.outputs.sarif }}
+          category: container-backend
+
+      - name: Scan frontend image (Grype)
+        uses: anchore/scan-action@v7.3.1
+        id: grype-frontend
+        with:
+          image: ${{ env.REGISTRY }}/le-coffre-frontend:${{ steps.set_outputs.outputs.image_tag }}
+          fail-build: true
+          severity-cutoff: critical
+          output-format: sarif
+
+      - name: Upload frontend scan results to GitHub Security
+        if: always() && steps.grype-frontend.outputs.sarif != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.grype-frontend.outputs.sarif }}
+          category: container-frontend
 
       - name: Generate changelog
         id: changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag version to build and release (e.g. v1.2.3)'
+        required: true
+        type: string
 
 env:
   REGISTRY: ghcr.io/${{ github.repository_owner }}
@@ -23,7 +29,12 @@ jobs:
 
       - name: Set image tag
         id: set_outputs
-        run: echo "image_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "image_tag=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "image_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.10.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,27 +49,6 @@ jobs:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/le-coffre-backend:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/le-coffre-backend:buildcache,mode=max,ignore-error=true
 
-      - name: Scan backend image (Grype)
-        uses: anchore/scan-action@v7.3.1
-        id: grype-backend
-        with:
-          image: ${{ env.REGISTRY }}/le-coffre-backend:${{ steps.set_outputs.outputs.image_tag }}
-          fail-build: true
-          severity-cutoff: critical
-          output-format: sarif
-
-      - name: Upload backend scan results to GitHub Security
-        if: always() && steps.grype-backend.outputs.sarif != ''
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: ${{ steps.grype-backend.outputs.sarif }}
-          category: container-backend
-
-      - name: Push backend image
-        run: |
-          docker push ${{ env.REGISTRY }}/le-coffre-backend:${{ steps.set_outputs.outputs.image_tag }}
-          docker push ${{ env.REGISTRY }}/le-coffre-backend:latest
-
       - name: Build frontend image
         uses: docker/build-push-action@v6.17.0
         with:
@@ -84,6 +63,15 @@ jobs:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/le-coffre-frontend:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/le-coffre-frontend:buildcache,mode=max,ignore-error=true
 
+      - name: Scan backend image (Grype)
+        uses: anchore/scan-action@v7.3.1
+        id: grype-backend
+        with:
+          image: ${{ env.REGISTRY }}/le-coffre-backend:${{ steps.set_outputs.outputs.image_tag }}
+          fail-build: true
+          severity-cutoff: critical
+          output-format: sarif
+
       - name: Scan frontend image (Grype)
         uses: anchore/scan-action@v7.3.1
         id: grype-frontend
@@ -93,6 +81,13 @@ jobs:
           severity-cutoff: critical
           output-format: sarif
 
+      - name: Upload backend scan results to GitHub Security
+        if: always() && steps.grype-backend.outputs.sarif != ''
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.grype-backend.outputs.sarif }}
+          category: container-backend
+
       - name: Upload frontend scan results to GitHub Security
         if: always() && steps.grype-frontend.outputs.sarif != ''
         uses: github/codeql-action/upload-sarif@v3
@@ -100,8 +95,10 @@ jobs:
           sarif_file: ${{ steps.grype-frontend.outputs.sarif }}
           category: container-frontend
 
-      - name: Push frontend image
+      - name: Push images
         run: |
+          docker push ${{ env.REGISTRY }}/le-coffre-backend:${{ steps.set_outputs.outputs.image_tag }}
+          docker push ${{ env.REGISTRY }}/le-coffre-backend:latest
           docker push ${{ env.REGISTRY }}/le-coffre-frontend:${{ steps.set_outputs.outputs.image_tag }}
           docker push ${{ env.REGISTRY }}/le-coffre-frontend:latest
 


### PR DESCRIPTION
## Summary

- Add Grype container scanning (backend + frontend) in `release.yml`: both images are built locally, both are scanned, and only pushed to ghcr.io if **all** scans pass — preventing any partially published release
- Results uploaded to GitHub Security tab via SARIF
- Add `workflow_dispatch` trigger on `release.yml` to allow manual runs from the GitHub Actions UI (with a tag input), in addition to the automatic `v*` tag push trigger

## Changes

### `release.yml`
- Add `security-events: write` permission
- `push: true` → `push: false, load: true` on both build steps (build locally first)
- Build both images **before** scanning either, so a frontend CVE cannot result in a partially published release
- Grype scan on backend then frontend — blocks on any critical CVE
- Upload SARIF results to GitHub Security tab (`always`, even if a scan blocked)
- Push both images only if all scans passed
- Add `workflow_dispatch` input to trigger the workflow manually from GitHub Actions UI

### `CI.yml`
- CodeQL SAST job added then removed (will be re-added later)

## Test plan

- [x] YAML syntax validated locally for both workflow files
- [x] Grype scans run locally — backend passes, frontend has critical CVEs (openssl/libxml2/libavif in nginx Alpine base image — separate fix needed)
- [x] Diff reviewed — no unintended changes
- [x] Branch rebased on main before push