### PR TITLE
Fix SyntaxError in Create Release step caused by backticks in changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,11 +175,13 @@ jobs:
 
       - name: Create Release
         uses: actions/github-script@v8
+        env:
+          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const tag = context.ref.replace('refs/tags/', '');
-            const changelog = `${{ steps.changelog.outputs.changelog }}`;
+            const changelog = process.env.CHANGELOG;
 
             let existingRelease;
             try {


### PR DESCRIPTION
## Summary

- The changelog generation script includes markdown code blocks with backticks (Docker images section)
- These backticks broke the JavaScript template literal used to interpolate the changelog in the `Create Release` step: `` const changelog = `${{ steps.changelog.outputs.changelog }}` ``
- Fix: pass the changelog via `process.env.CHANGELOG` instead of direct interpolation

## Test plan

- [x] YAML syntax validated locally
- [x] Root cause confirmed in CI logs: `SyntaxError: Unexpected identifier 'pull'`