### PR TITLE
Add only-fixed flag to Grype scans

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
           fail-build: true
           severity-cutoff: critical
           output-format: sarif
+          only-fixed: true
 
       - name: Scan frontend image (Grype)
         uses: anchore/scan-action@v7.3.1
@@ -91,6 +92,7 @@ jobs:
           fail-build: true
           severity-cutoff: critical
           output-format: sarif
+          only-fixed: true
 
       - name: Upload backend scan results to GitHub Security
         if: always() && steps.grype-backend.outputs.sarif != ''


### PR DESCRIPTION
Add only-fixed: true to both Grype scan steps in release.yml.

Grype SARIF output uses NVD CVSS scores while the terminal uses distro advisory levels. CVEs that Debian assessed as negligible/won't fix (CVE-2019-1010022, CVE-2005-2541) appeared as critical in GitHub Code Scanning despite not blocking the pipeline.

With only-fixed: true, only CVEs with an available fix are reported in both the pipeline and the SARIF uploaded to GitHub Security.

Test plan:
- YAML syntax validated locally
- Backend scan locally: 0 critical with --only-fixed
- Frontend scan locally: 0 vulnerabilities with --only-fixed