### PR TITLE
Fix workflow_dispatch: use image_tag output instead of GITHUB_REF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           # Get previous tag
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          CURRENT_TAG=${GITHUB_REF#refs/tags/}
+          CURRENT_TAG=${{ steps.set_outputs.outputs.image_tag }}
 
           # Generate changelog from commits
           if [ -z "$PREVIOUS_TAG" ]; then
@@ -182,7 +182,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const tag = context.ref.replace('refs/tags/', '');
+            const tag = '${{ steps.set_outputs.outputs.image_tag }}';
             const changelog = process.env.CHANGELOG;
 
             let existingRelease;


### PR DESCRIPTION
When triggered via workflow_dispatch, GITHUB_REF is refs/heads/main instead of a tag ref. Two places were still using GITHUB_REF directly instead of the image_tag output computed in the Set image tag step.

- Generate changelog: CURRENT_TAG now uses steps.set_outputs.outputs.image_tag
- Create Release: tag now uses steps.set_outputs.outputs.image_tag

The process.env.CHANGELOG fix (backtick issue) was already present.

Test plan:
- YAML syntax validated locally
- Root cause confirmed in CI logs: tag_name was refs/heads/main