### PR TITLE
feat: switch frontend to nginx-unprivileged on port 8080

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,11 +16,12 @@ RUN bun run build
 # =============================================================================
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 
+USER root
+
 # Apply latest security patches from Alpine repos
 RUN apk upgrade --no-cache
 
-# Remove default nginx config
-RUN rm /etc/nginx/conf.d/default.conf
+USER nginx
 
 # Copy custom nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
@@ -29,5 +30,3 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /frontend/dist /usr/share/nginx/html
 
 EXPOSE 8080
-
-CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,7 +14,7 @@ RUN bun run build
 # =============================================================================
 # Stage 2: Production Image (nginx)
 # =============================================================================
-FROM nginx:1.27-alpine
+FROM nginxinc/nginx-unprivileged:1.27-alpine
 
 # Apply latest security patches from Alpine repos
 RUN apk upgrade --no-cache
@@ -28,6 +28,6 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Copy built frontend files
 COPY --from=builder /frontend/dist /usr/share/nginx/html
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
 
     root /usr/share/nginx/html;

--- a/nginx-compose.conf
+++ b/nginx-compose.conf
@@ -1,5 +1,5 @@
 upstream frontend {
-    server frontend:80;
+    server frontend:8080;
 }
 
 upstream backend {

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -167,7 +167,7 @@ async def lifespan(app: FastAPI):
     app.state.csrf_token_manager = csrf_token_manager
 
     # SSO Gateway (stateless)
-    base_url = os.getenv("APP_BASE_URL", "http://localhost:8123")
+    base_url = os.getenv("APP_BASE_URL", "http://localhost:8123").rstrip("/")
     sso_gateway = OAuth2SsoGateway(
         redirect_uri=f"{base_url}/sso/callback",
         scope="openid email profile",

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -167,7 +167,7 @@ async def lifespan(app: FastAPI):
     app.state.csrf_token_manager = csrf_token_manager
 
     # SSO Gateway (stateless)
-    base_url = os.getenv("APP_BASE_URL", "http://localhost:8123").rstrip("/")
+    base_url = os.getenv("APP_BASE_URL", "http://localhost:8123")
     sso_gateway = OAuth2SsoGateway(
         redirect_uri=f"{base_url}/sso/callback",
         scope="openid email profile",


### PR DESCRIPTION
## Summary

- Replaces \`nginx:1.27-alpine\` with \`nginxinc/nginx-unprivileged:1.27-alpine\` in the frontend Dockerfile
- Updates \`nginx.conf\` to listen on port \`8080\` instead of \`80\`
- Updates \`nginx-compose.conf\` upstream to \`frontend:8080\`

## Why

\`nginx:1.27-alpine\` requires root (\`runAsUser: 0\`) to bind port 80 and to chown its temp directories. This forced the Kubernetes deployment to run with elevated privileges and extra capabilities (\`CHOWN\`, \`NET_BIND_SERVICE\`, \`SETGID\`, \`SETUID\`).

\`nginx-unprivileged\` runs as uid/gid 101 out of the box, listens on an unprivileged port (8080), and needs no Linux capabilities — enabling a clean \`drop: ALL\` securityContext.

## Related

- Companion PR in le-coffre-deployment: soma-smart/le-coffre-deployment#8 (update Helm chart for port 8080 + non-root securityContext — do not merge before this release)

## Test plan

- [x] Build the frontend image locally and verify it starts correctly: \`docker build -t le-coffre-frontend:test ./frontend && docker run --rm -p 8080:8080 le-coffre-frontend:test\`
- [x] Verify nginx serves on port 8080: \`curl http://localhost:8080\` → HTTP 200
- [ ] ~~Run the full dev stack: \`docker compose -f docker-compose.dev.yml up --build\`~~ — N/A: dev stack uses Vite directly, does not use the frontend nginx image or \`nginx-compose.conf\`
- [ ] ~~Verify the frontend is accessible via the proxy at \`http://localhost:8123\`~~ — N/A: same reason
- [x] Run frontend tests: \`cd frontend && bun run test:unit\` → 12/12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)