### PR TITLE
fix: wrap remaining async use cases' blocking DB calls in asyncio.to_thread

### DIFF
--- a/server/src/identity_access_management_context/application/use_cases/password_login_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/password_login_use_case.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from identity_access_management_context.application.commands import AdminLoginCommand
@@ -43,35 +44,41 @@ class PasswordLoginUseCase(TracedUseCase):
         self._admin_event_repository = admin_event_repository
 
     async def execute(self, command: AdminLoginCommand) -> AdminLoginResponse:
-        user_password = self._user_password_repository.get_by_email(command.email)
-        if not user_password:
-            logger.warning("Login failed for email=%s reason='User not found'", command.email)
-            event = AdminLoginFailedEvent(email=command.email, reason="User not found")
-            self._event_publisher.publish(event)
-            self._admin_event_repository.append_event(
-                event_id=event.event_id,
-                event_type=type(event).__name__,
-                occurred_on=event.occurred_on,
-                actor_user_id=None,
-                event_data={"email": command.email, "reason": "User not found"},
-            )
-            raise AdminNotFoundException("User not found")
+        # DB reads and bcrypt verification are synchronous and blocking — run
+        # them in a thread pool to avoid starving the event loop.
+        def _lookup_and_verify():
+            user_password = self._user_password_repository.get_by_email(command.email)
+            if not user_password:
+                logger.warning("Login failed for email=%s reason='User not found'", command.email)
+                event = AdminLoginFailedEvent(email=command.email, reason="User not found")
+                self._event_publisher.publish(event)
+                self._admin_event_repository.append_event(
+                    event_id=event.event_id,
+                    event_type=type(event).__name__,
+                    occurred_on=event.occurred_on,
+                    actor_user_id=None,
+                    event_data={"email": command.email, "reason": "User not found"},
+                )
+                raise AdminNotFoundException("User not found")
 
-        if not self._password_hashing_gateway.verify(command.password, user_password.password_hash):
-            logger.warning("Login failed for email=%s reason='Invalid credentials'", command.email)
-            event = AdminLoginFailedEvent(email=command.email, reason="Invalid credentials")
-            self._event_publisher.publish(event)
-            self._admin_event_repository.append_event(
-                event_id=event.event_id,
-                event_type=type(event).__name__,
-                occurred_on=event.occurred_on,
-                actor_user_id=None,
-                event_data={"email": command.email, "reason": "Invalid credentials"},
-            )
-            raise InvalidCredentialsException("Invalid credentials")
+            if not self._password_hashing_gateway.verify(command.password, user_password.password_hash):
+                logger.warning("Login failed for email=%s reason='Invalid credentials'", command.email)
+                event = AdminLoginFailedEvent(email=command.email, reason="Invalid credentials")
+                self._event_publisher.publish(event)
+                self._admin_event_repository.append_event(
+                    event_id=event.event_id,
+                    event_type=type(event).__name__,
+                    occurred_on=event.occurred_on,
+                    actor_user_id=None,
+                    event_data={"email": command.email, "reason": "Invalid credentials"},
+                )
+                raise InvalidCredentialsException("Invalid credentials")
 
-        user = self._user_repository.get_by_id(user_password.id)
-        roles = user.roles if user is not None else []
+            user = self._user_repository.get_by_id(user_password.id)
+            roles = user.roles if user is not None else []
+            return user_password, roles
+
+        user_password, roles = await asyncio.to_thread(_lookup_and_verify)
 
         token = await self._token_gateway.generate_token(
             user_id=user_password.id,
@@ -88,12 +95,14 @@ class PasswordLoginUseCase(TracedUseCase):
 
         event = AdminLoginEvent(admin_id=user_password.id, email=user_password.email)
         self._event_publisher.publish(event)
-        self._admin_event_repository.append_event(
-            event_id=event.event_id,
-            event_type=type(event).__name__,
-            occurred_on=event.occurred_on,
-            actor_user_id=user_password.id,
-            event_data={"email": user_password.email},
+        await asyncio.to_thread(
+            lambda: self._admin_event_repository.append_event(
+                event_id=event.event_id,
+                event_type=type(event).__name__,
+                occurred_on=event.occurred_on,
+                actor_user_id=user_password.id,
+                event_data={"email": user_password.email},
+            )
         )
 
         return AdminLoginResponse(

--- a/server/src/identity_access_management_context/application/use_cases/refresh_access_token_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/refresh_access_token_use_case.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from identity_access_management_context.application.commands import (
     RefreshAccessTokenCommand,
 )
@@ -32,7 +34,7 @@ class RefreshAccessTokenUseCase(TracedUseCase):
         if token_data is None:
             raise InvalidRefreshTokenException("Invalid or expired refresh token")
 
-        user = self.user_repository.get_by_id(token_data.user_id)
+        user = await asyncio.to_thread(self.user_repository.get_by_id, token_data.user_id)
         if user is None:
             raise InvalidRefreshTokenException("User no longer exists")
 

--- a/server/src/identity_access_management_context/application/use_cases/register_admin_with_password_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/register_admin_with_password_use_case.py
@@ -1,3 +1,4 @@
+import asyncio
 from uuid import UUID
 
 from identity_access_management_context.application.commands import (
@@ -44,47 +45,47 @@ class RegisterAdminWithPasswordUseCase(TracedUseCase):
         self._admin_event_repository = admin_event_repository
 
     async def execute(self, command: RegisterAdminWithPasswordCommand) -> UUID:
-        # Create service instance
-        user_management_service = UserManagementService(self._user_repository, self._password_hashing_gateway)
+        # All operations are synchronous DB/CPU work — run in a thread pool to
+        # avoid blocking the event loop.
+        def _run() -> UUID:
+            user_management_service = UserManagementService(self._user_repository, self._password_hashing_gateway)
 
-        # Check if admin can be created
-        if not user_management_service.can_create_admin():
-            raise AdminAlreadyExistsException("An admin account already exists")
+            if not user_management_service.can_create_admin():
+                raise AdminAlreadyExistsException("An admin account already exists")
 
-        # Hash password and save to password repository
-        password_hash = self._password_hashing_gateway.hash(command.password)
-        user_password = UserPassword(
-            id=command.id,
-            email=command.email,
-            password_hash=password_hash,
-            display_name=command.display_name,
-        )
-        self._user_password_repository.save(user_password)
+            password_hash = self._password_hashing_gateway.hash(command.password)
+            user_password = UserPassword(
+                id=command.id,
+                email=command.email,
+                password_hash=password_hash,
+                display_name=command.display_name,
+            )
+            self._user_password_repository.save(user_password)
 
-        # Create admin user via service
-        user = user_management_service.create_admin(
-            user_id=command.id,
-            email=command.email,
-            username=command.email.split("@")[0],
-            name=command.display_name,
-        )
+            user = user_management_service.create_admin(
+                user_id=command.id,
+                email=command.email,
+                username=command.email.split("@")[0],
+                name=command.display_name,
+            )
 
-        # Create personal group for the admin user
-        UserCreationService.create_personal_group_and_set_ownership(
-            user_id=user.id,
-            username=user.username,
-            group_repository=self._group_repository,
-            group_member_repository=self._group_member_repository,
-        )
+            UserCreationService.create_personal_group_and_set_ownership(
+                user_id=user.id,
+                username=user.username,
+                group_repository=self._group_repository,
+                group_member_repository=self._group_member_repository,
+            )
 
-        event = AdminRegisteredEvent(admin_id=user_password.id, email=command.email)
-        self._event_publisher.publish(event)
-        self._admin_event_repository.append_event(
-            event_id=event.event_id,
-            event_type=type(event).__name__,
-            occurred_on=event.occurred_on,
-            actor_user_id=user_password.id,
-            event_data={"email": command.email},
-        )
+            event = AdminRegisteredEvent(admin_id=user_password.id, email=command.email)
+            self._event_publisher.publish(event)
+            self._admin_event_repository.append_event(
+                event_id=event.event_id,
+                event_type=type(event).__name__,
+                occurred_on=event.occurred_on,
+                actor_user_id=user_password.id,
+                event_data={"email": command.email},
+            )
 
-        return user_password.id
+            return user_password.id
+
+        return await asyncio.to_thread(_run)

--- a/server/src/identity_access_management_context/application/use_cases/sso/sso_login_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/sso/sso_login_use_case.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime
 from uuid import uuid4
 
@@ -70,78 +71,75 @@ class SsoLoginUseCase(TracedUseCase):
         self._sso_event_repository = sso_event_repository
 
     async def execute(self, command: SsoLoginCommand) -> SsoLoginResponse:
-        # Step 0: Retrieve SSO and decrypt secret key
-        sso_config = SsoConfigurationDecryptingService(
-            self._sso_configuration_repository, self._sso_encryption_gateway
-        ).decrypt()
+        # Step 0: Retrieve SSO config — synchronous DB read + crypto, run in thread.
+        sso_config = await asyncio.to_thread(
+            lambda: SsoConfigurationDecryptingService(
+                self._sso_configuration_repository, self._sso_encryption_gateway
+            ).decrypt()
+        )
 
-        # Step 1: Validate SSO code and get user info from provider
+        # Step 1: Validate SSO code with the provider — truly async network call.
         sso_user_from_provider = await self._sso_gateway.validate_callback(
             sso_config, command.code, redirect_uri=command.redirect_uri
         )
 
-        # Step 2: Check if user already exists in our system
-        existing_sso_user = self._sso_user_repository.get_by_sso_user_id(
-            sso_user_from_provider.sso_user_id, sso_user_from_provider.sso_provider
-        )
-
-        if existing_sso_user:
-            # User exists, use existing data
-            user_id = existing_sso_user.internal_user_id
-            email = existing_sso_user.email
-            display_name = existing_sso_user.display_name
-            is_new_user = False
-
-            # Update last login time
-            self._sso_user_repository.update_last_login(
-                sso_user_from_provider.sso_user_id,
-                sso_user_from_provider.sso_provider,
-                datetime.now(),
-            )
-        else:
-            # Step 3: Create new user
-            user_id = uuid4()
-            email = sso_user_from_provider.email
-            display_name = sso_user_from_provider.display_name
-            is_new_user = True
-
-            # Create user in User Management context via service
-            user_management_service = UserManagementService(self._user_repository, self._password_hashing_gateway)
-            user = user_management_service.create_user(
-                user_id=user_id,
-                email=email,
-                username=email.split("@")[0],
-                name=display_name,
+        # Steps 2-4: All remaining DB reads/writes are synchronous — batch them
+        # in a single thread to avoid blocking the event loop between token calls.
+        def _resolve_user():
+            existing_sso_user = self._sso_user_repository.get_by_sso_user_id(
+                sso_user_from_provider.sso_user_id, sso_user_from_provider.sso_provider
             )
 
-            # Create personal group for the new user
-            UserCreationService.create_personal_group_and_set_ownership(
-                user_id=user.id,
-                username=user.username,
-                group_repository=self._group_repository,
-                group_member_repository=self._group_member_repository,
-            )
+            if existing_sso_user:
+                user_id = existing_sso_user.internal_user_id
+                email = existing_sso_user.email
+                display_name = existing_sso_user.display_name
+                is_new_user = False
+                self._sso_user_repository.update_last_login(
+                    sso_user_from_provider.sso_user_id,
+                    sso_user_from_provider.sso_provider,
+                    datetime.now(),
+                )
+            else:
+                user_id = uuid4()
+                email = sso_user_from_provider.email
+                display_name = sso_user_from_provider.display_name
+                is_new_user = True
 
-            # Save SSO user mapping in Auth context
-            sso_user = SsoUser(
-                internal_user_id=user_id,
-                email=email,
-                display_name=display_name,
-                sso_user_id=sso_user_from_provider.sso_user_id,
-                sso_provider=sso_user_from_provider.sso_provider,
-                created_at=datetime.now(),
-                last_login=datetime.now(),
-            )
-            self._sso_user_repository.create(sso_user)
+                user_management_service = UserManagementService(self._user_repository, self._password_hashing_gateway)
+                user = user_management_service.create_user(
+                    user_id=user_id,
+                    email=email,
+                    username=email.split("@")[0],
+                    name=display_name,
+                )
+                UserCreationService.create_personal_group_and_set_ownership(
+                    user_id=user.id,
+                    username=user.username,
+                    group_repository=self._group_repository,
+                    group_member_repository=self._group_member_repository,
+                )
+                sso_user = SsoUser(
+                    internal_user_id=user_id,
+                    email=email,
+                    display_name=display_name,
+                    sso_user_id=sso_user_from_provider.sso_user_id,
+                    sso_provider=sso_user_from_provider.sso_provider,
+                    created_at=datetime.now(),
+                    last_login=datetime.now(),
+                )
+                self._sso_user_repository.create(sso_user)
 
-        # Step 4: Fetch current roles from the User repository so that promotions
-        # (e.g. to admin) are reflected immediately in the new token.
-        user = self._user_repository.get_by_id(user_id)
-        if not user:
-            raise RuntimeError("User should exist at this point, but was not found in UserRepository")
-        roles = user.roles
+            # Fetch current roles so that any promotions are reflected in the token.
+            user = self._user_repository.get_by_id(user_id)
+            if not user:
+                raise RuntimeError("User should exist at this point, but was not found in UserRepository")
 
-        # Step 5: Generate JWT token
+            return user_id, email, display_name, is_new_user, user.roles
+
+        user_id, email, display_name, is_new_user, roles = await asyncio.to_thread(_resolve_user)
+
+        # Step 5: Generate JWT tokens — truly async.
         token = await self._token_gateway.generate_token(
             user_id=user_id,
             email=email,
@@ -157,12 +155,14 @@ class SsoLoginUseCase(TracedUseCase):
 
         event = SsoLoginEvent(user_id=user_id, email=email, is_new_user=is_new_user)
         self._event_publisher.publish(event)
-        self._sso_event_repository.append_event(
-            event_id=event.event_id,
-            event_type=type(event).__name__,
-            occurred_on=event.occurred_on,
-            actor_user_id=user_id,
-            event_data={"email": email, "is_new_user": is_new_user},
+        await asyncio.to_thread(
+            lambda: self._sso_event_repository.append_event(
+                event_id=event.event_id,
+                event_type=type(event).__name__,
+                occurred_on=event.occurred_on,
+                actor_user_id=user_id,
+                event_data={"email": email, "is_new_user": is_new_user},
+            )
         )
 
         return SsoLoginResponse(


### PR DESCRIPTION
## Summary

Follow-up to #254 which fixed the most critical blocking path (\`validate_user_token_use_case\`, called on every authenticated request). Four other \`async def execute\` use cases were also performing synchronous SQLAlchemy lookups directly on the event loop:

- **\`refresh_access_token_use_case\`** — user repository lookup before token generation
- **\`password_login_use_case\`** — email lookup + bcrypt \`verify\` (CPU-bound) + event DB writes on both success and failure paths
- **\`register_admin_with_password_use_case\`** — entire body was synchronous (no \`await\` calls at all); wrapped in a single \`_run\` closure
- **\`sso_login_use_case\`** — SSO config decrypt (DB + crypto), user resolution/creation block, event DB write

Each use case now runs its synchronous DB and CPU-bound work in a thread pool via \`asyncio.to_thread()\`, following the exact same pattern introduced in #254. Async gateway calls (\`token_gateway.generate_token\`, \`sso_gateway.validate_callback\`, etc.) remain awaited directly on the event loop.

## Test plan

- [x] \`uv run ruff format --check .\` passes
- [x] \`uv run ruff check .\` passes
- [x] \`uv run pytest .\` — 449 passed, 3 skipped (opentelemetry not installed locally)
- [ ] CI green (all workflows pass)