### PR TITLE
feat(helm): publish chart to ghcr.io OCI registry on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,28 @@ jobs:
           docker push ${{ env.REGISTRY }}/le-coffre-frontend:${{ steps.set_outputs.outputs.image_tag }}
           docker push ${{ env.REGISTRY }}/le-coffre-frontend:latest
 
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - name: Package and push Helm chart
+        run: |
+          SEMVER="${{ steps.set_outputs.outputs.image_tag }}"
+          SEMVER="${SEMVER#v}"
+
+          # Pin chart version to the release tag
+          sed -i "s/^version:.*/version: \"${SEMVER}\"/" helm/le-coffre/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"${SEMVER}\"/" helm/le-coffre/Chart.yaml
+
+          helm package helm/le-coffre --destination /tmp/helm-charts/
+
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+          helm push /tmp/helm-charts/le-coffre-${SEMVER}.tgz oci://ghcr.io/${{ github.repository_owner }}
+          echo "✅ Helm chart pushed: oci://ghcr.io/${{ github.repository_owner }}/le-coffre:${SEMVER}"
+
       - name: Generate changelog
         id: changelog
         run: |
@@ -140,6 +162,7 @@ jobs:
 
           # Add Docker images section
           REGISTRY="ghcr.io/${GITHUB_REPOSITORY_OWNER}"
+          SEMVER="${CURRENT_TAG#v}"
           CHANGELOG="$CHANGELOG\n## 🐳 Docker Images\n"
           CHANGELOG="$CHANGELOG\`\`\`\n"
           CHANGELOG="$CHANGELOG docker pull ${REGISTRY}/le-coffre-backend:${CURRENT_TAG}\n"
@@ -149,6 +172,11 @@ jobs:
           CHANGELOG="$CHANGELOG|-------|-----|------|\n"
           CHANGELOG="$CHANGELOG| Backend | \`${CURRENT_TAG}\` | [ghcr.io](https://ghcr.io/${GITHUB_REPOSITORY_OWNER}/le-coffre-backend) |\n"
           CHANGELOG="$CHANGELOG| Frontend | \`${CURRENT_TAG}\` | [ghcr.io](https://ghcr.io/${GITHUB_REPOSITORY_OWNER}/le-coffre-frontend) |\n"
+
+          CHANGELOG="$CHANGELOG\n## ⛵ Helm Chart\n"
+          CHANGELOG="$CHANGELOG\`\`\`\n"
+          CHANGELOG="$CHANGELOG helm install le-coffre oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/le-coffre --version ${SEMVER} -f values.yaml\n"
+          CHANGELOG="$CHANGELOG\`\`\`\n"
 
           CHANGELOG="$CHANGELOG\n\n## Changes\n"
 

--- a/helm/le-coffre/values.yaml
+++ b/helm/le-coffre/values.yaml
@@ -93,20 +93,20 @@ backend:
   probes:
     startupProbe:
       httpGet:
-        path: /api/health
+        path: /health
         port: 8080
       initialDelaySeconds: 10
       failureThreshold: 30
       periodSeconds: 5
     livenessProbe:
       httpGet:
-        path: /api/health
+        path: /health
         port: 8080
       periodSeconds: 30
       failureThreshold: 3
     readinessProbe:
       httpGet:
-        path: /api/health
+        path: /health/ready
         port: 8080
       periodSeconds: 10
       failureThreshold: 3


### PR DESCRIPTION
## Summary

- Package and push the Helm chart to `oci://ghcr.io/soma-smart/le-coffre` on each release, alongside the Docker images
- Chart version is pinned to the release semver tag at package time
- Fix backend probe paths: `/api/health` -> `/health` (startup/liveness) and `/health/ready` (readiness), aligned with what runs on the cluster today
- Add Helm install snippet to the release changelog

## Test plan

- [ ] CI green
- [ ] Release pipeline: verify Helm chart is pushed to `oci://ghcr.io/soma-smart/le-coffre:<semver>` after a tag push
- [ ] `helm install le-coffre oci://ghcr.io/soma-smart/le-coffre --version <semver> -f values.yaml` works from a clean environment

Generated with [Claude Code](https://claude.com/claude-code)