### PR TITLE
security: Harden XSS protections across frontend and backend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,8 +23,9 @@ RUN apk upgrade --no-cache
 
 USER nginx
 
-# Copy custom nginx config
+# Copy custom nginx config and security headers snippet
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY security_headers.conf /etc/nginx/security_headers.conf
 
 # Copy built frontend files
 COPY --from=builder /frontend/dist /usr/share/nginx/html

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self'" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+    add_header X-XSS-Protection "0" always;
+
     # Gzip compression
     gzip on;
     gzip_vary on;
@@ -16,6 +23,12 @@ server {
     location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self'" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+        add_header X-XSS-Protection "0" always;
     }
 
     # SPA fallback - serve index.html for all non-file routes

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,12 +5,7 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self'" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
-    add_header X-XSS-Protection "0" always;
+    include /etc/nginx/security_headers.conf;
 
     # Gzip compression
     gzip on;
@@ -23,12 +18,7 @@ server {
     location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
-        add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self'" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Frame-Options "DENY" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
-        add_header X-XSS-Protection "0" always;
+        include /etc/nginx/security_headers.conf;
     }
 
     # SPA fallback - serve index.html for all non-file routes

--- a/frontend/security_headers.conf
+++ b/frontend/security_headers.conf
@@ -1,0 +1,6 @@
+add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self'" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+add_header X-XSS-Protection "0" always;

--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -13,6 +13,7 @@ import { useCsrfStore } from '@/stores/csrf'
 import { pickDefaultGroupForUser } from '@/domain/group/Group'
 import { slugifyGroupName } from '@/utils/groupSlug'
 import { sortGroupsByName } from '@/utils/groupSort'
+import { normalizeExternalHttpUrl } from '@/utils/safeUrl'
 
 const router = useRouter()
 const route = useRoute()
@@ -180,7 +181,19 @@ const handleSsoLogin = async () => {
   ssoLoading.value = true
   try {
     const url = await auth.getSsoUrl.execute()
-    window.location.href = url
+    const ssoUrl = normalizeExternalHttpUrl(url)
+    if (!ssoUrl) {
+      toast.add({
+        severity: 'error',
+        summary: 'SSO Error',
+        detail: 'SSO provider returned an invalid login URL.',
+        life: 5000,
+      })
+      return
+    }
+
+    // Redirect to SSO provider
+    window.location.assign(ssoUrl)
   } catch (error) {
     console.error('SSO URL error:', error)
     const detail =

--- a/frontend/src/components/modals/CreatePasswordModal.vue
+++ b/frontend/src/components/modals/CreatePasswordModal.vue
@@ -2,13 +2,14 @@
 import { ref, toRef, watch, onMounted, computed } from 'vue'
 import { useToast } from 'primevue/usetoast'
 import { storeToRefs } from 'pinia'
-import { isValidPasswordUrl, type Password } from '@/domain/password/Password'
+import { type Password } from '@/domain/password/Password'
 import { PasswordDomainError } from '@/domain/password/errors'
 import PasswordGenerator from '@/components/passwords/PasswordGenerator.vue'
 import { useContainer } from '@/plugins/container'
 import { useModelFromEntity } from '@/composables/useModelFromEntity'
 import { useGroupsStore } from '@/stores/groups'
 import { usePasswordsStore } from '@/stores/passwords'
+import { isSafeHttpUrl, normalizeExternalHttpUrl } from '@/utils/safeUrl'
 
 const visible = defineModel<boolean>('visible', { required: true })
 
@@ -97,7 +98,7 @@ const searchFolders = (event: { query: string }) => {
 }
 
 const urlError = computed(() =>
-  isValidPasswordUrl(form.url) ? '' : 'URL must start with http:// or https://',
+  !form.url || isSafeHttpUrl(form.url) ? '' : 'URL must start with http:// or https://',
 )
 
 // Display bullets when password field is not focused
@@ -191,6 +192,7 @@ const handleSubmit = async () => {
 
   try {
     loading.value = true
+    const normalizedUrl = normalizeExternalHttpUrl(form.url)
 
     if (isEditMode.value && props.editPassword) {
       await passwordUseCases.update.execute({
@@ -199,7 +201,7 @@ const handleSubmit = async () => {
         password: form.password || null,
         folder: form.folder || null,
         login: form.login || null,
-        url: form.url || null,
+        url: normalizedUrl,
       })
 
       toast.add({
@@ -216,7 +218,7 @@ const handleSubmit = async () => {
         name: form.name,
         password: form.password,
         login: form.login || null,
-        url: form.url || null,
+        url: normalizedUrl,
         folder: form.folder || null,
         groupId: selectedGroupId.value!,
       })

--- a/frontend/src/components/passwords/PasswordCard.vue
+++ b/frontend/src/components/passwords/PasswordCard.vue
@@ -115,8 +115,8 @@
           {{ password.login }}
         </span>
         <a
-          v-if="password.url"
-          :href="password.url"
+          v-if="safePasswordUrl"
+          :href="safePasswordUrl"
           target="_blank"
           rel="noopener noreferrer"
           class="flex items-center gap-1 text-primary hover:underline"
@@ -124,6 +124,14 @@
           <i class="pi pi-external-link text-xs" />
           {{ password.url }}
         </a>
+        <span
+          v-else-if="password.url"
+          class="flex items-center gap-1 text-muted-color"
+          v-tooltip.top="'URL is not opened because it is not http(s)'"
+        >
+          <i class="pi pi-exclamation-triangle text-xs" />
+          {{ password.url }}
+        </span>
       </div>
 
       <div class="flex items-center justify-between gap-4 text-xs text-muted-color">
@@ -161,6 +169,7 @@ import { useContainer } from '@/plugins/container'
 import { useGroupsStore } from '@/stores/groups'
 import { usePasswordReveal } from '@/composables/usePasswordReveal'
 import { usePasswordSharedAccess } from '@/composables/usePasswordSharedAccess'
+import { normalizeExternalHttpUrl } from '@/utils/safeUrl'
 
 const actorUsernameCache = new Map<string, string>()
 
@@ -188,6 +197,7 @@ const { passwords: passwordUseCases, users: userUseCases } = useContainer()
 
 const isDeleting = ref(false)
 const needsUpdate = computed(() => isPasswordStale(props.password))
+const safePasswordUrl = computed(() => normalizeExternalHttpUrl(props.password.url))
 
 const canWriteInContext = computed(() => {
   if (!props.password.canWrite) {

--- a/frontend/src/utils/safeUrl.test.ts
+++ b/frontend/src/utils/safeUrl.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSafeHttpUrl, normalizeExternalHttpUrl } from './safeUrl'
+
+describe('safeUrl', () => {
+  it.each(['https://example.com', 'http://example.com/path?q=1', ' HTTPS://example.com '])(
+    'accepts %s',
+    (url) => {
+      expect(isSafeHttpUrl(url)).toBe(true)
+      expect(normalizeExternalHttpUrl(url)).toMatch(/^https?:\/\//i)
+    },
+  )
+
+  it.each([
+    'javascript:alert(1)',
+    'data:text/html,<script></script>',
+    '//example.com',
+    '/local',
+    'ftp://example.com',
+  ])('rejects %s', (url) => {
+    expect(isSafeHttpUrl(url)).toBe(false)
+    expect(normalizeExternalHttpUrl(url)).toBeNull()
+  })
+})

--- a/frontend/src/utils/safeUrl.ts
+++ b/frontend/src/utils/safeUrl.ts
@@ -1,0 +1,18 @@
+const HTTP_PROTOCOLS = new Set(['http:', 'https:'])
+
+export const normalizeExternalHttpUrl = (value: string | null | undefined): string | null => {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  try {
+    const url = new URL(trimmed)
+    return HTTP_PROTOCOLS.has(url.protocol) && !!url.hostname ? url.href : null
+  } catch {
+    return null
+  }
+}
+
+export const isSafeHttpUrl = (value: string | null | undefined): boolean =>
+  normalizeExternalHttpUrl(value) !== null

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -61,6 +61,7 @@ from security import (
     CsrfTokenManager,
     InMemoryRateLimiter,
     RateLimitMiddleware,
+    SecurityHeadersMiddleware,
     csrf_router,
 )
 from shared_kernel.adapters.primary.request_id_middleware import (
@@ -249,6 +250,7 @@ app = FastAPI(lifespan=lifespan, root_path="/api")
 
 
 # Add CSRF protection middleware
+app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(CsrfMiddleware)
 app.add_middleware(RequestIdMiddleware)
 

--- a/server/src/password_management_context/adapters/primary/fastapi/request_validation.py
+++ b/server/src/password_management_context/adapters/primary/fastapi/request_validation.py
@@ -1,0 +1,18 @@
+"""Validation helpers for browser-opened password URLs."""
+
+from urllib.parse import urlparse
+
+
+def normalize_optional_http_url(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    normalized = value.strip()
+    if not normalized:
+        return None
+
+    parsed = urlparse(normalized)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("URL must start with http:// or https://")
+
+    return normalized

--- a/server/src/password_management_context/adapters/primary/fastapi/routes/password_create_routes.py
+++ b/server/src/password_management_context/adapters/primary/fastapi/routes/password_create_routes.py
@@ -2,10 +2,13 @@ import logging
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from password_management_context.adapters.primary.fastapi.app_dependencies import (
     get_create_password_usecase,
+)
+from password_management_context.adapters.primary.fastapi.request_validation import (
+    normalize_optional_http_url,
 )
 from password_management_context.application.commands import CreatePasswordCommand
 from password_management_context.application.use_cases import CreatePasswordUseCase
@@ -29,6 +32,11 @@ class CreatePasswordRequest(BaseModel):
     login: str | None = None
     url: str | None = None
     group_id: str
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str | None) -> str | None:
+        return normalize_optional_http_url(value)
 
 
 class CreatePasswordResponse(BaseModel):

--- a/server/src/password_management_context/adapters/primary/fastapi/routes/password_update_routes.py
+++ b/server/src/password_management_context/adapters/primary/fastapi/routes/password_update_routes.py
@@ -2,10 +2,13 @@ import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from password_management_context.adapters.primary.fastapi.app_dependencies import (
     get_update_password_usecase,
+)
+from password_management_context.adapters.primary.fastapi.request_validation import (
+    normalize_optional_http_url,
 )
 from password_management_context.application.commands import UpdatePasswordCommand
 from password_management_context.application.use_cases import UpdatePasswordUseCase
@@ -30,6 +33,11 @@ class UpdatePasswordRequest(BaseModel):
     folder: str | None = None
     login: str | None = None
     url: str | None = None
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str | None) -> str | None:
+        return normalize_optional_http_url(value)
 
 
 @router.put(

--- a/server/src/security/__init__.py
+++ b/server/src/security/__init__.py
@@ -5,6 +5,7 @@ from .csrf_routes import router as csrf_router
 from .csrf_tokens import CsrfTokenManager
 from .rate_limit_middleware import RateLimitMiddleware
 from .rate_limiter import InMemoryRateLimiter, RateLimitResult
+from .security_headers_middleware import SecurityHeadersMiddleware
 
 __all__ = [
     "CsrfMiddleware",
@@ -13,4 +14,5 @@ __all__ = [
     "InMemoryRateLimiter",
     "RateLimitResult",
     "RateLimitMiddleware",
+    "SecurityHeadersMiddleware",
 ]

--- a/server/src/security/security_headers_middleware.py
+++ b/server/src/security/security_headers_middleware.py
@@ -23,18 +23,13 @@ CONTENT_SECURITY_POLICY = (
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Attach conservative browser security headers to every response."""
 
-    @staticmethod
-    def _is_docs_or_openapi_path(path: str) -> bool:
-        """Return True for FastAPI documentation and OpenAPI schema endpoints."""
-        return path == "/api/docs" or path.startswith("/api/openapi")
-
     async def dispatch(
         self,
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
         response = await call_next(request)
-        if not self._is_docs_or_openapi_path(request.url.path):
+        if not _is_docs_request(request):
             response.headers.setdefault("Content-Security-Policy", CONTENT_SECURITY_POLICY)
         response.headers.setdefault("X-Content-Type-Options", "nosniff")
         response.headers.setdefault("X-Frame-Options", "DENY")
@@ -45,3 +40,28 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         )
         response.headers.setdefault("X-XSS-Protection", "0")
         return response
+
+
+def _is_docs_request(request: Request) -> bool:
+    """Return True for Swagger/ReDoc/OpenAPI endpoints, however the app is deployed.
+
+    Doc paths are read from FastAPI itself (never hard-coded). The request path is
+    normalised by stripping root_path first, so it matches whether or not the proxy
+    keeps the mount prefix (e.g. /api) and whatever root_path/docs_url is configured.
+    """
+    app = request.app
+    path = request.url.path
+    root_path = request.scope.get("root_path", "")
+    if root_path and path.startswith(root_path):
+        path = path[len(root_path) :] or "/"
+    doc_paths = {
+        candidate
+        for candidate in (
+            app.docs_url,
+            app.redoc_url,
+            app.openapi_url,
+            app.swagger_ui_oauth2_redirect_url,
+        )
+        if candidate
+    }
+    return path in doc_paths

--- a/server/src/security/security_headers_middleware.py
+++ b/server/src/security/security_headers_middleware.py
@@ -23,13 +23,19 @@ CONTENT_SECURITY_POLICY = (
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Attach conservative browser security headers to every response."""
 
+    @staticmethod
+    def _is_docs_or_openapi_path(path: str) -> bool:
+        """Return True for FastAPI documentation and OpenAPI schema endpoints."""
+        return path == "/api/docs" or path.startswith("/api/openapi")
+
     async def dispatch(
         self,
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
         response = await call_next(request)
-        response.headers.setdefault("Content-Security-Policy", CONTENT_SECURITY_POLICY)
+        if not self._is_docs_or_openapi_path(request.url.path):
+            response.headers.setdefault("Content-Security-Policy", CONTENT_SECURITY_POLICY)
         response.headers.setdefault("X-Content-Type-Options", "nosniff")
         response.headers.setdefault("X-Frame-Options", "DENY")
         response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")

--- a/server/src/security/security_headers_middleware.py
+++ b/server/src/security/security_headers_middleware.py
@@ -1,0 +1,41 @@
+"""Security response headers for browser-facing API responses."""
+
+from collections.abc import Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+CONTENT_SECURITY_POLICY = (
+    "default-src 'self'; "
+    "base-uri 'self'; "
+    "object-src 'none'; "
+    "frame-ancestors 'none'; "
+    "form-action 'self'; "
+    "img-src 'self' data:; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "font-src 'self' data:; "
+    "connect-src 'self'"
+)
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach conservative browser security headers to every response."""
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        response = await call_next(request)
+        response.headers.setdefault("Content-Security-Policy", CONTENT_SECURITY_POLICY)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
+        response.headers.setdefault(
+            "Permissions-Policy",
+            "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
+        )
+        response.headers.setdefault("X-XSS-Protection", "0")
+        return response

--- a/server/tests/e2e/test_password_management_workflow.py
+++ b/server/tests/e2e/test_password_management_workflow.py
@@ -164,7 +164,7 @@ def test_complete_password_management_workflow(client_factory, setup, configured
             "password": "NewStrongP@ssw0rd!",
             "folder": "Personal",
             "login": "NEW " + LOGIN,
-            "url": "NEW " + URL,
+            "url": "http://new.example.com",
         },
     )
     assert update_response.status_code == 201
@@ -182,7 +182,7 @@ def test_complete_password_management_workflow(client_factory, setup, configured
     assert updated_meta["name"] == "Updated Password"
     assert updated_meta["folder"] == "Personal"
     assert updated_meta["login"] == "NEW " + LOGIN
-    assert updated_meta["url"] == "NEW " + URL
+    assert updated_meta["url"] == "http://new.example.com"
 
     # Verify timestamps: created_at should stay same, last_updated_at should change
     assert updated_meta["created_at"] == original_created_at, "created_at should not change after update"

--- a/server/tests/password_management_context/integration/test_password_url_validation_routes.py
+++ b/server/tests/password_management_context/integration/test_password_url_validation_routes.py
@@ -1,0 +1,77 @@
+from uuid import UUID, uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from password_management_context.adapters.primary.fastapi.routes.password_create_routes import (
+    router as create_password_router,
+)
+from password_management_context.adapters.primary.fastapi.routes.password_update_routes import (
+    router as update_password_router,
+)
+from shared_kernel.domain.entities import ValidatedUser
+
+
+class _UseCaseShouldNotExecute:
+    def execute(self, *_args, **_kwargs):
+        raise AssertionError("unsafe payload should be rejected before the use case executes")
+
+
+def _create_app() -> FastAPI:
+    app = FastAPI()
+    app.dependency_overrides.clear()
+
+    async def current_user_override():
+        return ValidatedUser(
+            user_id=UUID("11111111-1111-1111-1111-111111111111"),
+            email="admin@example.com",
+            display_name="Admin",
+            roles=["ADMIN"],
+        )
+
+    def create_usecase_override():
+        return _UseCaseShouldNotExecute()
+
+    def update_usecase_override():
+        return _UseCaseShouldNotExecute()
+
+    from password_management_context.adapters.primary.fastapi.app_dependencies import (
+        get_create_password_usecase,
+        get_update_password_usecase,
+    )
+    from shared_kernel.adapters.primary.dependencies import get_current_user
+
+    app.dependency_overrides[get_current_user] = current_user_override
+    app.dependency_overrides[get_create_password_usecase] = create_usecase_override
+    app.dependency_overrides[get_update_password_usecase] = update_usecase_override
+    app.include_router(create_password_router)
+    app.include_router(update_password_router)
+    return app
+
+
+def test_given_javascript_url_when_creating_password_should_return_422():
+    with TestClient(_create_app()) as client:
+        response = client.post(
+            "/passwords/",
+            json={
+                "name": "malicious",
+                "password": "secret",
+                "group_id": str(uuid4()),
+                "url": "javascript:alert(1)",
+            },
+        )
+
+    assert response.status_code == 422
+
+
+def test_given_data_url_when_updating_password_should_return_422():
+    with TestClient(_create_app()) as client:
+        response = client.put(
+            f"/passwords/{uuid4()}",
+            json={
+                "name": "malicious",
+                "url": "data:text/html,<script>alert(1)</script>",
+            },
+        )
+
+    assert response.status_code == 422

--- a/server/tests/security/unit/test_security_headers_middleware.py
+++ b/server/tests/security/unit/test_security_headers_middleware.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+from security.security_headers_middleware import CONTENT_SECURITY_POLICY, SecurityHeadersMiddleware
+
+
+def test_given_response_when_dispatching_should_add_browser_security_headers():
+    app = FastAPI()
+    app.add_middleware(SecurityHeadersMiddleware)
+
+    @app.get("/ok")
+    async def ok():
+        return PlainTextResponse("ok")
+
+    with TestClient(app) as client:
+        response = client.get("/ok")
+
+    assert response.headers["Content-Security-Policy"] == CONTENT_SECURITY_POLICY
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
+    assert response.headers["Permissions-Policy"] == "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+    assert response.headers["X-XSS-Protection"] == "0"

--- a/server/tests/security/unit/test_security_headers_middleware.py
+++ b/server/tests/security/unit/test_security_headers_middleware.py
@@ -5,13 +5,19 @@ from starlette.testclient import TestClient
 from security.security_headers_middleware import CONTENT_SECURITY_POLICY, SecurityHeadersMiddleware
 
 
-def test_given_response_when_dispatching_should_add_browser_security_headers():
-    app = FastAPI()
+def _build_app(**kwargs) -> FastAPI:
+    app = FastAPI(**kwargs)
     app.add_middleware(SecurityHeadersMiddleware)
 
     @app.get("/ok")
     async def ok():
         return PlainTextResponse("ok")
+
+    return app
+
+
+def test_given_response_when_dispatching_should_add_browser_security_headers():
+    app = _build_app()
 
     with TestClient(app) as client:
         response = client.get("/ok")
@@ -22,3 +28,45 @@ def test_given_response_when_dispatching_should_add_browser_security_headers():
     assert response.headers["Referrer-Policy"] == "strict-origin-when-cross-origin"
     assert response.headers["Permissions-Policy"] == "camera=(), microphone=(), geolocation=(), payment=(), usb=()"
     assert response.headers["X-XSS-Protection"] == "0"
+
+
+def test_given_openapi_endpoint_when_dispatching_should_omit_csp_but_keep_other_headers():
+    app = _build_app()
+
+    with TestClient(app) as client:
+        response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    assert "Content-Security-Policy" not in response.headers
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+
+
+def test_given_docs_endpoint_when_dispatching_should_omit_csp():
+    app = _build_app()
+
+    with TestClient(app) as client:
+        response = client.get("/docs")
+
+    assert response.status_code == 200
+    assert "Content-Security-Policy" not in response.headers
+
+
+def test_given_root_path_when_requesting_openapi_should_still_omit_csp():
+    app = _build_app(root_path="/api")
+
+    with TestClient(app) as client:
+        response = client.get("/api/openapi.json")
+
+    assert response.status_code == 200
+    assert "Content-Security-Policy" not in response.headers
+
+
+def test_given_non_docs_route_when_dispatching_should_apply_csp():
+    app = _build_app(root_path="/api")
+
+    with TestClient(app) as client:
+        response = client.get("/api/ok")
+
+    assert response.status_code == 200
+    assert response.headers["Content-Security-Policy"] == CONTENT_SECURITY_POLICY


### PR DESCRIPTION
# Pull Request Title

## Description
This PR hardens XSS protections across the application by adding browser security headers, validating user-provided URLs, and preventing unsafe links or redirects from being opened in the frontend.

Changes : 
- Add global FastAPI security headers middleware:
  - Content-Security-Policy
  - X-Content-Type-Options
  - X-Frame-Options
  - Referrer-Policy
  - Permissions-Policy
- Add equivalent security headers to the frontend nginx config.
- Validate password URLs on create/update API routes.
- Allow only `http://` and `https://` URLs for password entries.
- Add frontend URL safety utilities.
- Prevent unsafe stored password URLs from being rendered as clickable links.
- Validate SSO redirect URLs before navigating.
- Update the password management E2E workflow to use a valid updated URL.
- Add targeted backend and frontend tests for the new protections.


## Related Issues
<!-- List any related issues or tasks. Use "Fixes #<issue_number>" to automatically close the issue when the PR is merged. -->
- Fixes #

## Checklist
- [x] I have tested the changes locally.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have ensured that my code follows the project's coding standards.

## Screenshots (if applicable)
<!-- Add screenshots to help explain the changes, if applicable. -->
