### PR TITLE
Security/sso ssrf hardening

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -19,7 +19,7 @@
     {
       "label": "Start Backend",
       "type": "shell",
-      "command": "cd /app/server && uv run fastapi dev src/main.py --host 0.0.0.0",
+      "command": "cd /app/server && SSO_ALLOW_PRIVATE_NETWORKS=true uv run fastapi dev src/main.py --host 0.0.0.0",
       "dependsOn": ["Start Nginx"],
       "isBackground": true,
       "problemMatcher": [],

--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -677,7 +677,9 @@ export const configureSsoProviderAuthSsoConfigurePost = <ThrowOnError extends bo
  *
  * Get the SSO authorization URL.
  *
- * Returns the SSO authorization URL.
+ * Generates a CSRF ``state`` bound to the caller via an httpOnly cookie,
+ * embeds it in the authorization URL, and returns that URL. The state is
+ * verified against the cookie when the provider calls back.
  */
 export const getSsoUrlAuthSsoUrlGet = <ThrowOnError extends boolean = false>(options?: Options<GetSsoUrlAuthSsoUrlGetData, ThrowOnError>) => (options?.client ?? client).get<GetSsoUrlAuthSsoUrlGetResponses, GetSsoUrlAuthSsoUrlGetErrors, ThrowOnError>({ url: '/auth/sso/url', ...options });
 

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -104,6 +104,17 @@ def get_rate_limit_trusted_proxy_hops() -> int:
     return int(os.environ.get("RATE_LIMIT_TRUSTED_PROXY_HOPS", "1"))
 
 
+def get_sso_allow_private_networks() -> bool:
+    """Allow SSO endpoints to target http/private/internal addresses.
+
+    Default ``false`` (secure-by-default): SSO URLs must be https and must not
+    resolve to private/loopback/link-local addresses, preventing SSRF against
+    internal services and cloud metadata endpoints. Set to ``true`` only for
+    local development or the localhost-bound OIDC mock used in tests.
+    """
+    return os.environ.get("SSO_ALLOW_PRIVATE_NETWORKS", "false").lower() == "true"
+
+
 # ── Login Lockout ────────────────────────────────────────────────
 
 

--- a/server/src/identity_access_management_context/adapters/primary/fastapi/routes/sso/get_sso_url_route.py
+++ b/server/src/identity_access_management_context/adapters/primary/fastapi/routes/sso/get_sso_url_route.py
@@ -1,7 +1,9 @@
 import logging
+import secrets
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 
+from config import get_cookie_secure_setting
 from identity_access_management_context.adapters.primary.fastapi.app_dependencies import (
     get_sso_url_usecase,
 )
@@ -17,6 +19,9 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
+SSO_STATE_COOKIE = "sso_state"
+SSO_STATE_MAX_AGE_SECONDS = 600
+
 
 @router.get(
     "/sso/url",
@@ -25,16 +30,31 @@ router = APIRouter(prefix="/auth", tags=["Authentication"])
     responses={404: {"description": "SSO not configured"}, 503: {"description": "Vault is locked"}},
 )
 async def get_sso_url(
+    response: Response,
     usecase: GetSsoAuthorizeUrlUseCase = Depends(get_sso_url_usecase),
 ):
     """
     Get the SSO authorization URL.
 
-    Returns the SSO authorization URL.
+    Generates a CSRF ``state`` bound to the caller via an httpOnly cookie,
+    embeds it in the authorization URL, and returns that URL. The state is
+    verified against the cookie when the provider calls back.
     """
     try:
-        command = GetSsoAuthorizeUrlCommand()
-        return await usecase.execute(command)
+        state = secrets.token_urlsafe(32)
+        command = GetSsoAuthorizeUrlCommand(state=state)
+        authorize_url = await usecase.execute(command)
+
+        response.set_cookie(
+            key=SSO_STATE_COOKIE,
+            value=state,
+            httponly=True,
+            secure=get_cookie_secure_setting(),
+            samesite="lax",  # must survive the top-level GET redirect back from the IdP
+            max_age=SSO_STATE_MAX_AGE_SECONDS,
+        )
+
+        return authorize_url
     except SsoConfigurationNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except SsoEncryptionUnavailableError as e:

--- a/server/src/identity_access_management_context/adapters/primary/fastapi/routes/sso/sso_callback_route.py
+++ b/server/src/identity_access_management_context/adapters/primary/fastapi/routes/sso/sso_callback_route.py
@@ -1,7 +1,8 @@
 import logging
+import secrets
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from pydantic import BaseModel
 
 from config import (
@@ -11,6 +12,9 @@ from config import (
 )
 from identity_access_management_context.adapters.primary.fastapi.app_dependencies import (
     get_sso_login_usecase,
+)
+from identity_access_management_context.adapters.primary.fastapi.routes.sso.get_sso_url_route import (
+    SSO_STATE_COOKIE,
 )
 from identity_access_management_context.application.commands.sso_login_command import (
     SsoLoginCommand,
@@ -47,6 +51,7 @@ class SsoCallbackResponse(BaseModel):
     responses={503: {"description": "Vault is locked"}},
 )
 async def sso_callback(
+    request: Request,
     response: Response,
     code: str = Query(..., description="Authorization code from SSO provider"),
     state: str = Query(None, description="State parameter for CSRF protection"),
@@ -65,6 +70,12 @@ async def sso_callback(
 
     Returns user information and sets HTTP-only secure cookies with JWT tokens.
     """
+    expected_state = request.cookies.get(SSO_STATE_COOKIE)
+    if not state or not expected_state or not secrets.compare_digest(state, expected_state):
+        response.delete_cookie(SSO_STATE_COOKIE)
+        raise HTTPException(status_code=400, detail="Invalid SSO state")
+    response.delete_cookie(SSO_STATE_COOKIE)
+
     try:
         command = SsoLoginCommand(code=code, redirect_uri=redirect_uri)
         result = await usecase.execute(command)
@@ -110,7 +121,7 @@ async def sso_callback(
             ),
         )
     except InvalidSsoCodeException as e:
-        raise HTTPException(status_code=400, detail=f"SSO authentication failed: {str(e)}") from e
+        raise HTTPException(status_code=400, detail="SSO authentication failed") from e
     except SsoEncryptionUnavailableError as e:
         raise HTTPException(status_code=503, detail=str(e)) from e
     except IdentityAccessManagementDomainError as e:

--- a/server/src/identity_access_management_context/adapters/secondary/__init__.py
+++ b/server/src/identity_access_management_context/adapters/secondary/__init__.py
@@ -9,12 +9,14 @@ from .sql.sql_sso_configuration_repository import SqlSsoConfigurationRepository
 from .sql.sql_sso_user_repository import SqlSsoUserRepository
 from .sql.sql_user_password_repository import SqlUserPasswordRepository
 from .sql.sql_user_repository import SqlUserRepository
+from .sso_url_validator import SsoUrlValidator
 
 __all__ = [
     "BcryptHashingGateway",
     "InMemoryLoginLockoutGateway",
     "JwtTokenGateway",
     "OAuth2SsoGateway",
+    "SsoUrlValidator",
     "SqlSsoUserRepository",
     "SqlUserRepository",
     "SqlUserPasswordRepository",

--- a/server/src/identity_access_management_context/adapters/secondary/oauth2_sso_gateway.py
+++ b/server/src/identity_access_management_context/adapters/secondary/oauth2_sso_gateway.py
@@ -1,9 +1,13 @@
+import logging
 from typing import Any
 from urllib.parse import urlencode
 
 import httpx
 from authlib.integrations.httpx_client import AsyncOAuth2Client
 
+from identity_access_management_context.adapters.secondary.sso_url_validator import (
+    SsoUrlValidator,
+)
 from identity_access_management_context.application.gateways import (
     SsoDiscoveryResult,
     SsoGateway,
@@ -14,6 +18,10 @@ from identity_access_management_context.domain.exceptions import (
     InvalidSsoCodeException,
     InvalidSsoSettingsException,
 )
+
+logger = logging.getLogger(__name__)
+
+_HTTP_TIMEOUT_SECONDS = 10.0
 
 
 class OAuth2SsoGateway(SsoGateway):
@@ -28,10 +36,12 @@ class OAuth2SsoGateway(SsoGateway):
         redirect_uri: str,
         scope: str = "openid email profile",
         provider: str = "default",
+        url_validator: SsoUrlValidator | None = None,
     ):
         self.redirect_uri = redirect_uri
         self.scope = scope
         self.provider = provider
+        self._url_validator = url_validator or SsoUrlValidator()
 
     async def validate_discovery(
         self,
@@ -40,32 +50,41 @@ class OAuth2SsoGateway(SsoGateway):
         discovery_url: str,
     ) -> SsoDiscoveryResult:
         """Validate SSO discovery configuration and return endpoints."""
+        self._url_validator.validate(discovery_url)
+
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS, follow_redirects=False) as client:
                 response = await client.get(discovery_url)
                 response.raise_for_status()
                 config = response.json()
-
-                # Validate required fields
-                required_fields = ["authorization_endpoint", "token_endpoint"]
-                missing_fields = [field for field in required_fields if field not in config]
-                if missing_fields:
-                    raise InvalidSsoSettingsException(f"Missing fields in discovery: {missing_fields}")
-
-                return SsoDiscoveryResult(
-                    authorization_endpoint=config["authorization_endpoint"],
-                    token_endpoint=config["token_endpoint"],
-                    userinfo_endpoint=config.get("userinfo_endpoint", ""),
-                    jwks_uri=config.get("jwks_uri", ""),
-                )
         except InvalidSsoSettingsException:
             raise
-        except httpx.TimeoutException as e:
-            raise InvalidSsoSettingsException("Timeout in discovering endpoints") from e
-        except httpx.HTTPStatusError as e:
-            raise InvalidSsoSettingsException(f"HTTP error during discovery: {e.response.status_code}") from e
         except Exception as e:
-            raise InvalidSsoSettingsException(f"Error during discovery of endpoints: {str(e)}") from e
+            logger.warning("SSO discovery request failed for %s: %s", discovery_url, e)
+            raise InvalidSsoSettingsException("Unable to retrieve the SSO discovery document") from e
+
+        required_fields = ["authorization_endpoint", "token_endpoint"]
+        missing_fields = [field for field in required_fields if field not in config]
+        if missing_fields:
+            raise InvalidSsoSettingsException("The SSO discovery document is missing required fields")
+
+        discovery_result = SsoDiscoveryResult(
+            authorization_endpoint=config["authorization_endpoint"],
+            token_endpoint=config["token_endpoint"],
+            userinfo_endpoint=config.get("userinfo_endpoint", ""),
+            jwks_uri=config.get("jwks_uri", ""),
+        )
+
+        for endpoint in (
+            discovery_result.authorization_endpoint,
+            discovery_result.token_endpoint,
+            discovery_result.userinfo_endpoint,
+            discovery_result.jwks_uri,
+        ):
+            if endpoint:
+                self._url_validator.validate(endpoint)
+
+        return discovery_result
 
     def _get_oauth_client(self, config: SsoConfiguration) -> AsyncOAuth2Client:
         """Get or create the OAuth2 client from stored configuration."""
@@ -75,16 +94,18 @@ class OAuth2SsoGateway(SsoGateway):
             client_secret=config.client_secret_decrypted,
             scope=self.scope,
             redirect_uri=self.redirect_uri,
+            timeout=_HTTP_TIMEOUT_SECONDS,
+            follow_redirects=False,
         )
 
-    async def get_authorize_url(self, config) -> str:
+    async def get_authorize_url(self, config: SsoConfiguration, state: str | None = None) -> str:
         """Generate OAuth2 authorization URL."""
         client = self._get_oauth_client(config)
 
-        # Generate authorization URL with state parameter for security
-        authorization_url, state = client.create_authorization_url(
+        # Generate authorization URL with a caller-provided state for CSRF protection
+        authorization_url, _ = client.create_authorization_url(
             config.authorization_endpoint,
-            state=client.token.get("state") if isinstance(client.token, dict) else None,
+            state=state,
         )
 
         return authorization_url
@@ -107,6 +128,11 @@ class OAuth2SsoGateway(SsoGateway):
                           If None, uses the server's default redirect_uri.
         """
 
+        # Re-validate persisted endpoints before any outbound call (defense in depth:
+        # configs stored before this guard existed, or DNS rebinding, must not reach internal hosts).
+        self._url_validator.validate(config.token_endpoint)
+        self._url_validator.validate(config.userinfo_endpoint)
+
         # Use override redirect_uri if provided (for CLI auth), otherwise use default
         effective_redirect_uri = redirect_uri or self.redirect_uri
 
@@ -124,7 +150,7 @@ class OAuth2SsoGateway(SsoGateway):
             )
 
             # Fetch user information
-            async with httpx.AsyncClient() as http_client:
+            async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS, follow_redirects=False) as http_client:
                 # Set the token for authorized requests
                 client.token = token
 
@@ -146,8 +172,11 @@ class OAuth2SsoGateway(SsoGateway):
                 sso_provider=self.provider,
             )
 
+        except InvalidSsoCodeException:
+            raise
         except Exception as e:
-            raise InvalidSsoCodeException(f"Failed to validate SSO code: {str(e)}") from e
+            logger.warning("SSO callback validation failed: %s", e)
+            raise InvalidSsoCodeException("SSO authentication failed") from e
 
     def _extract_email(self, user_info: dict[str, Any]) -> str:
         """Extract email from user info based on provider."""

--- a/server/src/identity_access_management_context/adapters/secondary/oauth2_sso_gateway.py
+++ b/server/src/identity_access_management_context/adapters/secondary/oauth2_sso_gateway.py
@@ -63,16 +63,16 @@ class OAuth2SsoGateway(SsoGateway):
             logger.warning("SSO discovery request failed for %s: %s", discovery_url, e)
             raise InvalidSsoSettingsException("Unable to retrieve the SSO discovery document") from e
 
-        required_fields = ["authorization_endpoint", "token_endpoint"]
-        missing_fields = [field for field in required_fields if field not in config]
+        required_fields = ["authorization_endpoint", "token_endpoint", "userinfo_endpoint"]
+        missing_fields = [field for field in required_fields if not config.get(field)]
         if missing_fields:
             raise InvalidSsoSettingsException("The SSO discovery document is missing required fields")
 
         discovery_result = SsoDiscoveryResult(
             authorization_endpoint=config["authorization_endpoint"],
             token_endpoint=config["token_endpoint"],
-            userinfo_endpoint=config.get("userinfo_endpoint", ""),
-            jwks_uri=config.get("jwks_uri", ""),
+            userinfo_endpoint=config["userinfo_endpoint"],
+            jwks_uri=config.get("jwks_uri"),
         )
 
         for endpoint in (

--- a/server/src/identity_access_management_context/adapters/secondary/oauth2_sso_gateway.py
+++ b/server/src/identity_access_management_context/adapters/secondary/oauth2_sso_gateway.py
@@ -66,7 +66,9 @@ class OAuth2SsoGateway(SsoGateway):
         required_fields = ["authorization_endpoint", "token_endpoint", "userinfo_endpoint"]
         missing_fields = [field for field in required_fields if not config.get(field)]
         if missing_fields:
-            raise InvalidSsoSettingsException("The SSO discovery document is missing required fields")
+            raise InvalidSsoSettingsException(
+                f"The SSO discovery document is missing required fields: {missing_fields}"
+            )
 
         discovery_result = SsoDiscoveryResult(
             authorization_endpoint=config["authorization_endpoint"],

--- a/server/src/identity_access_management_context/adapters/secondary/sso_url_validator.py
+++ b/server/src/identity_access_management_context/adapters/secondary/sso_url_validator.py
@@ -1,0 +1,54 @@
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+from identity_access_management_context.domain.exceptions import (
+    DisallowedSsoEndpointException,
+)
+
+_DEFAULT_PORT_BY_SCHEME = {"https": 443, "http": 80}
+
+
+class SsoUrlValidator:
+    """Guards SSO endpoint URLs against SSRF.
+
+    Forces https and rejects any URL whose hostname resolves to a
+    private, loopback, link-local, reserved, multicast or unspecified
+    address (covers cloud metadata endpoints such as 169.254.169.254).
+
+    When ``allow_private_networks`` is True the guard is relaxed to permit
+    http and internal addresses, which is required only for local
+    development and the localhost-bound OIDC mock used in tests.
+    """
+
+    def __init__(self, allow_private_networks: bool = False) -> None:
+        self._allow_private_networks = allow_private_networks
+
+    def validate(self, url: str) -> None:
+        parsed = urlparse((url or "").strip())
+        scheme = parsed.scheme.lower()
+
+        allowed_schemes = {"https", "http"} if self._allow_private_networks else {"https"}
+        if scheme not in allowed_schemes or not parsed.hostname:
+            raise DisallowedSsoEndpointException()
+
+        if self._allow_private_networks:
+            return
+
+        port = parsed.port or _DEFAULT_PORT_BY_SCHEME[scheme]
+        try:
+            resolved = socket.getaddrinfo(parsed.hostname, port, proto=socket.IPPROTO_TCP)
+        except socket.gaierror as error:
+            raise DisallowedSsoEndpointException() from error
+
+        for *_, sockaddr in resolved:
+            ip = ipaddress.ip_address(sockaddr[0])
+            if (
+                ip.is_private
+                or ip.is_loopback
+                or ip.is_link_local
+                or ip.is_reserved
+                or ip.is_multicast
+                or ip.is_unspecified
+            ):
+                raise DisallowedSsoEndpointException()

--- a/server/src/identity_access_management_context/application/commands/get_sso_authorize_url_command.py
+++ b/server/src/identity_access_management_context/application/commands/get_sso_authorize_url_command.py
@@ -3,4 +3,4 @@ from dataclasses import dataclass
 
 @dataclass
 class GetSsoAuthorizeUrlCommand:
-    pass
+    state: str | None = None

--- a/server/src/identity_access_management_context/application/gateways/sso_gateway.py
+++ b/server/src/identity_access_management_context/application/gateways/sso_gateway.py
@@ -28,7 +28,7 @@ class SsoDiscoveryResult:
 
 
 class SsoGateway(Protocol):
-    async def get_authorize_url(self, config: SsoConfiguration) -> str: ...
+    async def get_authorize_url(self, config: SsoConfiguration, state: str | None = None) -> str: ...
 
     async def validate_callback(
         self, config: SsoConfiguration, code: str, redirect_uri: str | None = None

--- a/server/src/identity_access_management_context/application/use_cases/sso/get_sso_authorize_url_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/sso/get_sso_authorize_url_use_case.py
@@ -28,4 +28,4 @@ class GetSsoAuthorizeUrlUseCase(TracedUseCase):
             self._sso_configuration_repository, self._sso_encryption_gateway
         ).decrypt()
 
-        return await self._sso_gateway.get_authorize_url(sso_config)
+        return await self._sso_gateway.get_authorize_url(sso_config, command.state)

--- a/server/src/identity_access_management_context/domain/exceptions.py
+++ b/server/src/identity_access_management_context/domain/exceptions.py
@@ -42,6 +42,13 @@ class InvalidSsoSettingsException(AuthenticationDomainError):
     pass
 
 
+class DisallowedSsoEndpointException(InvalidSsoSettingsException):
+    """Raised when an SSO URL targets a disallowed scheme or a private/internal address."""
+
+    def __init__(self, message: str = "The provided SSO URL is not allowed") -> None:
+        super().__init__(message)
+
+
 class InvalidRefreshTokenException(AuthenticationDomainError):
     pass
 

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -286,6 +286,27 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
     )
 
 
+def _is_health_probe(path: str) -> bool:
+    """Liveness/readiness probes must stay reachable while the app is starting up."""
+    normalized = path.rstrip("/")
+    return normalized.endswith("/health") or normalized.endswith("/health/ready")
+
+
+@app.middleware("http")
+async def readiness_gate(request: Request, call_next):
+    """Return 503 until background migrations finish, instead of leaking raw DB errors.
+
+    Database-backed routes would otherwise hit tables that do not exist yet during
+    the startup window and surface a 500 with a raw ``no such table`` message. The
+    health probes are exempt so liveness/readiness keep reporting the real state.
+    """
+    if not _is_health_probe(request.url.path) and not getattr(request.app.state, "ready", False):
+        if getattr(request.app.state, "migration_failed", False):
+            return JSONResponse(status_code=503, content={"detail": "Service unavailable: database migrations failed"})
+        return JSONResponse(status_code=503, content={"detail": "Service starting: database migrations in progress"})
+    return await call_next(request)
+
+
 # Liveness probe: process is alive and event loop is responsive.
 # Fails only if migrations have fatally failed, to trigger a Kubernetes restart.
 # Note: With root_path="/api", this will be accessible at /api/health

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -35,6 +35,7 @@ from config import (
     get_rate_limit_unauth_max_requests,
     get_rate_limit_user_max_requests,
     get_rate_limit_window_seconds,
+    get_sso_allow_private_networks,
 )
 from identity_access_management_context.adapters.primary.fastapi.routes import (
     get_admin_management_router,
@@ -48,6 +49,7 @@ from identity_access_management_context.adapters.secondary import (
     JwtTokenGateway,
     OAuth2SsoGateway,
     PrivateApiSsoEncryptionGateway,
+    SsoUrlValidator,
 )
 from monitoring import setup_logging, setup_monitoring
 from password_management_context.adapters.primary.fastapi.routes import (
@@ -181,6 +183,7 @@ async def lifespan(app: FastAPI):
         redirect_uri=f"{base_url}/sso/callback",
         scope="openid email profile",
         provider="oauth2",
+        url_validator=SsoUrlValidator(allow_private_networks=get_sso_allow_private_networks()),
     )
     app.state.sso_gateway = sso_gateway
 

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -46,6 +46,9 @@ def env_vars():
     # gateway honors *some* finite window and that the use case clears state
     # when it elapses.
     os.environ["LOGIN_LOCKOUT_SECONDS"] = "1"
+    # The e2e OIDC mock is bound to http://localhost; relax the SSRF guard so the
+    # SSO discovery/token/userinfo flow can reach it. Production defaults to strict.
+    os.environ["SSO_ALLOW_PRIVATE_NETWORKS"] = "true"
     yield
     for key in (
         "JWT_SECRET_KEY",
@@ -54,5 +57,6 @@ def env_vars():
         "RATE_LIMIT_UNAUTH_MAX_REQUESTS",
         "RATE_LIMIT_AUTH_MAX_REQUESTS",
         "LOGIN_LOCKOUT_SECONDS",
+        "SSO_ALLOW_PRIVATE_NETWORKS",
     ):
         os.environ.pop(key, None)

--- a/server/tests/e2e/conftest.py
+++ b/server/tests/e2e/conftest.py
@@ -141,6 +141,10 @@ def database(database_path):
 @pytest.fixture
 def e2e_client(database, env_vars):
     with CsrfTestClient(app) as client:
+        # The `database` fixture already applied migrations, so bypass the startup
+        # readiness gate (which would otherwise 503 while the background migration
+        # task races the test's requests).
+        app.state.ready = True
         yield client
 
 
@@ -285,9 +289,10 @@ def authenticate_sso_user(e2e_client, oidc_server, sso_user):
     query_params = parse_qs(parsed.query)
     valid_code = query_params.get("code", [None])[0]
     assert valid_code, f"Authorization code not found in callback URL: {callback_url}"
+    returned_state = query_params.get("state", [None])[0]
 
-    # Exchange code for token
-    valid_callback_response = e2e_client.get(f"/api/auth/sso/callback?code={valid_code}")
+    # Exchange code for token (echo back the CSRF state so it matches the sso_state cookie)
+    valid_callback_response = e2e_client.get(f"/api/auth/sso/callback?code={valid_code}&state={returned_state}")
     assert valid_callback_response.status_code == 200, f"Valid callback failed: {valid_callback_response.text}"
 
     callback_data = valid_callback_response.json()
@@ -394,7 +399,11 @@ def client_factory(database, env_vars):
     """
 
     def _make_client():
-        return CsrfTestClient(app)
+        client = CsrfTestClient(app)
+        # The `database` fixture already applied migrations; keep the app marked
+        # ready so the startup readiness gate does not 503 these clients.
+        app.state.ready = True
+        return client
 
     return _make_client
 

--- a/server/tests/e2e/test_complete_authentication_workflow.py
+++ b/server/tests/e2e/test_complete_authentication_workflow.py
@@ -350,11 +350,14 @@ async def test_complete_authentication_workflow(
 
     assert isinstance(sso_url, str)
     assert "http" in sso_url.lower()
+    # The CSRF state is embedded in the URL and bound to the caller via the sso_state cookie.
+    sso_state = parse_qs(urlparse(sso_url).query).get("state", [None])[0]
+    assert sso_state, "SSO authorization URL should carry a state parameter"
     print(f"✅ SSO authorization URL obtained: {sso_url[:50]}...")
 
-    # Step 5.5: Test invalid authorization code
+    # Step 5.5: Test invalid authorization code (with a valid state so we reach the code check)
     print("\n🚫 Step 5.5: Testing SSO callback with invalid code...")
-    invalid_callback_response = e2e_client.get("/api/auth/sso/callback?code=invalid-code-12345")
+    invalid_callback_response = e2e_client.get(f"/api/auth/sso/callback?code=invalid-code-12345&state={sso_state}")
     assert invalid_callback_response.status_code == 400
     error_data = invalid_callback_response.json()
     assert (
@@ -364,8 +367,15 @@ async def test_complete_authentication_workflow(
     )
     print("✅ Invalid SSO code correctly rejected (400)")
 
-    # Step 5.6: Simulate user authorization and get valid code
+    # Step 5.6: Simulate user authorization and get valid code.
+    # Re-fetch the URL to obtain a fresh state + sso_state cookie (the previous
+    # callback consumed/cleared the cookie).
     print("\n🔐 Step 5.6: Simulating user authorization to get valid code...")
+    fresh_url_response = e2e_client.get("/api/auth/sso/url")
+    assert fresh_url_response.status_code == 200
+    fresh_sso_url_data = fresh_url_response.json()
+    sso_url = fresh_sso_url_data if isinstance(fresh_sso_url_data, str) else str(fresh_sso_url_data)
+
     auth_response = httpx.post(
         sso_url,
         data={"sub": oidc_test_user["sub"]},
@@ -379,12 +389,13 @@ async def test_complete_authentication_workflow(
     parsed = urlparse(callback_url)
     query_params = parse_qs(parsed.query)
     valid_code = query_params.get("code", [None])[0]
+    valid_state = query_params.get("state", [None])[0]
     assert valid_code
     print(f"✅ Valid authorization code obtained: {valid_code[:10]}...")
 
     # Step 5.7: Complete SSO login with valid code
     print("\n✨ Step 5.7: Completing SSO login with valid code...")
-    valid_callback_response = e2e_client.get(f"/api/auth/sso/callback?code={valid_code}")
+    valid_callback_response = e2e_client.get(f"/api/auth/sso/callback?code={valid_code}&state={valid_state}")
     assert valid_callback_response.status_code == 200
 
     callback_data = valid_callback_response.json()

--- a/server/tests/e2e/test_rate_limiting_workflow.py
+++ b/server/tests/e2e/test_rate_limiting_workflow.py
@@ -25,6 +25,8 @@ from security.rate_limiter import InMemoryRateLimiter
 @pytest.fixture
 def rate_limited_client(database, env_vars):
     with CsrfTestClient(app) as client:
+        # DB already migrated by the `database` fixture; bypass the startup readiness gate.
+        app.state.ready = True
         # Override limits on the live app state so phases trip deterministically.
         app.state.rate_limit_user_max_requests = 50
         app.state.rate_limit_unauth_max_requests = 5

--- a/server/tests/e2e/test_sso_security.py
+++ b/server/tests/e2e/test_sso_security.py
@@ -1,0 +1,33 @@
+from urllib.parse import parse_qs, urlparse
+
+
+def _extract_sso_url(response) -> str:
+    data = response.json()
+    return data if isinstance(data, str) else str(data)
+
+
+def test_sso_url_sets_state_cookie_matching_the_url(e2e_client, configured_sso):
+    response = e2e_client.get("/api/auth/sso/url")
+    assert response.status_code == 200
+
+    state_in_url = parse_qs(urlparse(_extract_sso_url(response)).query).get("state", [None])[0]
+    assert state_in_url, "authorization URL must carry a state parameter"
+    assert e2e_client.cookies.get("sso_state") == state_in_url
+
+
+def test_sso_callback_without_state_is_rejected(e2e_client, configured_sso):
+    e2e_client.get("/api/auth/sso/url")  # sets the sso_state cookie
+
+    response = e2e_client.get("/api/auth/sso/callback?code=anything")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid SSO state"
+
+
+def test_sso_callback_with_mismatched_state_is_rejected(e2e_client, configured_sso):
+    e2e_client.get("/api/auth/sso/url")  # sets the sso_state cookie
+
+    response = e2e_client.get("/api/auth/sso/callback?code=anything&state=forged-state")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid SSO state"

--- a/server/tests/e2e/test_startup_readiness_gate.py
+++ b/server/tests/e2e/test_startup_readiness_gate.py
@@ -1,0 +1,43 @@
+from main import app
+
+
+def test_db_routes_return_503_while_migrations_in_progress(e2e_client):
+    app.state.ready = False
+    app.state.migration_failed = False
+    try:
+        response = e2e_client.get("/api/vault/status")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Service starting: database migrations in progress"
+    finally:
+        app.state.ready = True
+
+
+def test_db_routes_return_503_when_migrations_failed(e2e_client):
+    app.state.ready = False
+    app.state.migration_failed = True
+    try:
+        response = e2e_client.get("/api/vault/status")
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Service unavailable: database migrations failed"
+    finally:
+        app.state.ready = True
+        app.state.migration_failed = False
+
+
+def test_health_probes_stay_reachable_while_not_ready(e2e_client):
+    app.state.ready = False
+    app.state.migration_failed = False
+    try:
+        liveness = e2e_client.get("/api/health")
+        assert liveness.status_code == 200
+
+        readiness = e2e_client.get("/api/health/ready")
+        assert readiness.status_code == 503  # honestly reports "not ready"
+    finally:
+        app.state.ready = True
+
+
+def test_db_routes_served_normally_once_ready(e2e_client):
+    app.state.ready = True
+    response = e2e_client.get("/api/vault/status")
+    assert response.status_code == 200

--- a/server/tests/identity_access_management_context/integration/test_sso_oidc_integration.py
+++ b/server/tests/identity_access_management_context/integration/test_sso_oidc_integration.py
@@ -5,7 +5,7 @@ import httpx
 import oidc_provider_mock
 import pytest
 
-from identity_access_management_context.adapters.secondary import OAuth2SsoGateway
+from identity_access_management_context.adapters.secondary import OAuth2SsoGateway, SsoUrlValidator
 from identity_access_management_context.application.gateways import SsoGateway
 from identity_access_management_context.domain.entities import SsoConfiguration
 from identity_access_management_context.domain.exceptions import InvalidSsoSettingsException
@@ -85,6 +85,7 @@ def sso_gateway(oidc_server) -> OAuth2SsoGateway:
     """OAuth2 SSO Gateway configured to use the OIDC mock server."""
     gateway = OAuth2SsoGateway(
         redirect_uri=oidc_server["redirect_uri"],
+        url_validator=SsoUrlValidator(allow_private_networks=True),
     )
     return gateway
 
@@ -208,6 +209,58 @@ async def test_oauth2_flow_with_invalid_code(sso_gateway: SsoGateway, oidc_serve
     assert "invalid" in error_message or "fail" in error_message or "error" in error_message
 
 
+@pytest.fixture
+def strict_gateway() -> OAuth2SsoGateway:
+    """Gateway with the production-default (strict) SSRF guard."""
+    return OAuth2SsoGateway(redirect_uri="https://app.example.com/sso/callback")
+
+
+def _internal_config(token_endpoint: str, userinfo_endpoint: str) -> SsoConfiguration:
+    return SsoConfiguration(
+        client_id="x",
+        client_secret="encrypted(x)",
+        discovery_url="https://idp.example.com/.well-known/openid-configuration",
+        authorization_endpoint="https://idp.example.com/authorize",
+        token_endpoint=token_endpoint,
+        userinfo_endpoint=userinfo_endpoint,
+        jwks_uri="https://idp.example.com/jwks",
+        updated_at=datetime.fromtimestamp(0),
+        client_secret_decrypted="x",
+    )
+
+
+@pytest.mark.asyncio
+async def test_should_reject_discovery_url_targeting_cloud_metadata(strict_gateway: OAuth2SsoGateway):
+    with pytest.raises(InvalidSsoSettingsException) as exc_info:
+        await strict_gateway.validate_discovery(
+            client_id="x",
+            client_secret="x",
+            discovery_url="https://169.254.169.254/latest/meta-data/",
+        )
+    # No network detail must leak (blind SSRF oracle).
+    assert "169.254" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_should_reject_http_discovery_url_in_strict_mode(strict_gateway: OAuth2SsoGateway):
+    with pytest.raises(InvalidSsoSettingsException):
+        await strict_gateway.validate_discovery(
+            client_id="x",
+            client_secret="x",
+            discovery_url="http://accounts.google.com/.well-known/openid_configuration",
+        )
+
+
+@pytest.mark.asyncio
+async def test_should_reject_internal_token_endpoint_on_callback(strict_gateway: OAuth2SsoGateway):
+    config = _internal_config(
+        token_endpoint="http://127.0.0.1:5432/token",
+        userinfo_endpoint="https://idp.example.com/userinfo",
+    )
+    with pytest.raises(InvalidSsoSettingsException):
+        await strict_gateway.validate_callback(config, "any-code")
+
+
 @pytest.mark.asyncio
 async def test_oidc_discovery_with_invalid_url(sso_gateway: SsoGateway):
     """Test that invalid discovery URL fails gracefully."""
@@ -297,6 +350,7 @@ async def test_complete_oauth2_flow_with_redirect_uri_override(oidc_test_user):
     # but the CLI flow provides its own redirect_uri at callback time.
     gateway = OAuth2SsoGateway(
         redirect_uri=oidc_server["redirect_uri"],
+        url_validator=SsoUrlValidator(allow_private_networks=True),
     )
 
     sso_discovery_result = await gateway.validate_discovery(

--- a/server/tests/identity_access_management_context/integration/test_sso_url_validator.py
+++ b/server/tests/identity_access_management_context/integration/test_sso_url_validator.py
@@ -1,0 +1,69 @@
+import socket
+
+import pytest
+
+from identity_access_management_context.adapters.secondary import SsoUrlValidator
+from identity_access_management_context.domain.exceptions import (
+    DisallowedSsoEndpointException,
+)
+
+
+def _fake_getaddrinfo(ip: str):
+    def _resolver(host, port, *args, **kwargs):
+        family = socket.AF_INET6 if ":" in ip else socket.AF_INET
+        return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))]
+
+    return _resolver
+
+
+class TestSsoUrlValidatorStrict:
+    def test_should_accept_https_public_host(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+        SsoUrlValidator().validate("https://accounts.google.com/.well-known/openid_configuration")
+
+    def test_should_reject_http_scheme(self):
+        with pytest.raises(DisallowedSsoEndpointException):
+            SsoUrlValidator().validate("http://accounts.google.com/.well-known/openid_configuration")
+
+    def test_should_reject_missing_host(self):
+        with pytest.raises(DisallowedSsoEndpointException):
+            SsoUrlValidator().validate("https:///no-host")
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "169.254.169.254",  # cloud metadata (IMDS)
+            "127.0.0.1",
+            "10.0.0.5",
+            "172.16.0.1",
+            "192.168.1.1",
+            "::1",
+            "0.0.0.0",  # noqa: S104 — intentional SSRF test vector (unspecified address)
+        ],
+    )
+    def test_should_reject_internal_ip(self, monkeypatch, ip):
+        monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo(ip))
+        with pytest.raises(DisallowedSsoEndpointException):
+            SsoUrlValidator().validate("https://internal.example.com/.well-known/openid_configuration")
+
+    def test_should_reject_public_host_rebinding_to_private_ip(self, monkeypatch):
+        monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("10.1.2.3"))
+        with pytest.raises(DisallowedSsoEndpointException):
+            SsoUrlValidator().validate("https://evil.example.com/.well-known/openid_configuration")
+
+    def test_should_reject_unresolvable_host(self, monkeypatch):
+        def _boom(*args, **kwargs):
+            raise socket.gaierror("name resolution failed")
+
+        monkeypatch.setattr(socket, "getaddrinfo", _boom)
+        with pytest.raises(DisallowedSsoEndpointException):
+            SsoUrlValidator().validate("https://does-not-exist.invalid/.well-known/openid_configuration")
+
+
+class TestSsoUrlValidatorPermissive:
+    def test_should_allow_http_localhost_when_private_networks_allowed(self):
+        SsoUrlValidator(allow_private_networks=True).validate("http://localhost:8080/.well-known/openid-configuration")
+
+    def test_should_still_reject_non_http_scheme(self):
+        with pytest.raises(DisallowedSsoEndpointException):
+            SsoUrlValidator(allow_private_networks=True).validate("file:///etc/passwd")

--- a/server/tests/identity_access_management_context/unit/fakes/fake_sso_gateway.py
+++ b/server/tests/identity_access_management_context/unit/fakes/fake_sso_gateway.py
@@ -14,8 +14,10 @@ class FakeSsoGateway(SsoGateway):
         self._discovery_error: Exception | None = None
         self._discovery_result: SsoDiscoveryResult | None = None
         self.last_redirect_uri: str | None = None
+        self.last_state: str | None = None
 
-    async def get_authorize_url(self, config: SsoConfiguration) -> str:
+    async def get_authorize_url(self, config: SsoConfiguration, state: str | None = None) -> str:
+        self.last_state = state
         return self._authorize_url
 
     async def validate_callback(


### PR DESCRIPTION
# security: SSRF hardening of the SSO OAuth2 flow + startup readiness gate

## Description
Fixes an SSRF vulnerability chain in the OAuth2/OIDC SSO integration (SSRF-VULN-01/02/03) and adds OAuth state CSRF protection on the callback. Also fixes a pre-existing startup race that leaked raw DB errors.

SSRF hardening (SSO gateway). discovery_url, and the authorization/token/userinfo/jwks endpoints returned by the discovery document, were fetched by httpx with no scheme/host/IP validation - reachable targets included 169.254.169.254 (cloud IMDS -> IAM credential theft), loopback and private ranges. The token/userinfo endpoints are re-called on every unauthenticated GET /api/auth/sso/callback (POSTing the client_secret, forwarding the Bearer token), and the userinfo call had no timeout.

New SsoUrlValidator: forces https, resolves the hostname and rejects private / loopback / link-local / reserved / multicast / unspecified IPs (covers 127/8, 10/8, 172.16/12, 192.168/16, 169.254/16, ::1, fc00::/7).
Validates the discovery URL before fetching, the discovered endpoints before persisting, and re-validates token/userinfo at callback time (defense in depth for configs stored before this fix).
Adds timeouts and follow_redirects=False on every outbound call.
Returns generic error messages (no status/host/timing) - removes the blind-SSRF port-scan oracle.
Secure by default: strict in production; opt-in via SSO_ALLOW_PRIVATE_NETWORKS=true for local dev / the localhost OIDC mock.
OAuth state CSRF. GET /api/auth/sso/url now issues a random state bound to the caller via an httpOnly sso_state cookie; GET /api/auth/sso/callback verifies it (constant-time) before doing anything and clears the cookie.

Startup readiness gate. DB-backed routes returned a 500 with a raw no such table message while background migrations were still running. A middleware now returns a clean 503 until the app is ready; /health and /health/ready stay reachable.

⚠️ Behavior change for operators: any local/internal IdP (e.g. dev Keycloak at http://keycloak:8080/...) now requires SSO_ALLOW_PRIVATE_NETWORKS=true; it is added to the "Start Backend" dev task. Production stays strict.



## Related Issues
<!-- List any related issues or tasks. Use "Fixes #<issue_number>" to automatically close the issue when the PR is merged. -->
- Fixes #

## Checklist
- [x] I have tested the changes locally.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have ensured that my code follows the project's coding standards.

## Screenshots (if applicable)
<!-- Add screenshots to help explain the changes, if applicable. -->
