### PR TITLE
security: rate-limit and throttle vault unlock/setup endpoints (AUTHZ-VULN-11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,12 @@ RATE_LIMIT_ENABLED=true
 RATE_LIMIT_AUTH_MAX_REQUESTS=5
 # Max requests per sliding window for general API routes.
 RATE_LIMIT_API_MAX_REQUESTS=60
+# Per-IP floor on the vault mutation endpoints (unlock/clear/setup).
+RATE_LIMIT_VAULT_MAX_REQUESTS=30
+# Global throttle (all callers/IPs) on destructive vault ops (clear, setup):
+# at most N per window — stops the looped clear/setup DoS.
+RATE_LIMIT_VAULT_SENSITIVE_MAX_REQUESTS=1
+RATE_LIMIT_VAULT_SENSITIVE_WINDOW_SECONDS=60
 # Sliding window duration in seconds.
 RATE_LIMIT_WINDOW_SECONDS=60
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -60,6 +60,17 @@ RATE_LIMIT_UNAUTH_MAX_REQUESTS=30
 # endpoint that submits credentials on every call (default: 100)
 RATE_LIMIT_AUTH_MAX_REQUESTS=100
 
+# Per-IP volume floor on the vault mutation endpoints (/vault/unlock,
+# /vault/unlock/clear, /vault/setup, /vault/validate-setup) (default: 30)
+RATE_LIMIT_VAULT_MAX_REQUESTS=30
+
+# GLOBAL throttle (single shared bucket, all callers/IPs) on the destructive
+# vault operations /vault/unlock/clear and /vault/setup: at most this many per
+# window, so an attacker cannot loop them to block unlocking / overwrite a
+# setup in progress (default: 1 per RATE_LIMIT_VAULT_SENSITIVE_WINDOW_SECONDS)
+RATE_LIMIT_VAULT_SENSITIVE_MAX_REQUESTS=1
+RATE_LIMIT_VAULT_SENSITIVE_WINDOW_SECONDS=60
+
 # Comma-separated TCP peer IPs whose X-Forwarded-For header is trusted.
 # Default covers the standard nginx-on-same-host setup; expand for
 # multi-hop proxy chains (CDN → nginx → backend, K8s ingress, etc.).

--- a/server/src/config.py
+++ b/server/src/config.py
@@ -83,6 +83,32 @@ def get_rate_limit_auth_max_requests() -> int:
     return int(os.environ.get("RATE_LIMIT_AUTH_MAX_REQUESTS", "100"))
 
 
+def get_rate_limit_vault_max_requests() -> int:
+    """Max requests per window on vault-mutation endpoints (per-IP vault floor). Default 30.
+
+    Covers the unauthenticated unlock flow (``/vault/unlock``, ``/vault/unlock/clear``),
+    ``/vault/setup`` and ``/vault/validate-setup``. A per-IP floor blunts flooding without
+    hindering the legitimate low-volume unlock ceremony.
+    """
+    return int(os.environ.get("RATE_LIMIT_VAULT_MAX_REQUESTS", "30"))
+
+
+def get_rate_limit_vault_sensitive_max_requests() -> int:
+    """Max destructive vault operations allowed per sensitive window, GLOBALLY. Default 1.
+
+    Applies a single shared bucket (all callers, all IPs) to the destructive ``/vault/unlock/clear``
+    and the vault-overwriting ``/vault/setup``. Combined with the window below this enforces
+    "at most once per minute" so an anonymous attacker cannot loop those operations to prevent
+    unlocking / re-initialize a setup in progress.
+    """
+    return int(os.environ.get("RATE_LIMIT_VAULT_SENSITIVE_MAX_REQUESTS", "1"))
+
+
+def get_rate_limit_vault_sensitive_window_seconds() -> int:
+    """Window for the global destructive-vault-operation throttle. Default 60 (1 minute)."""
+    return int(os.environ.get("RATE_LIMIT_VAULT_SENSITIVE_WINDOW_SECONDS", "60"))
+
+
 def get_rate_limit_window_seconds() -> int:
     """Sliding window duration in seconds. Default 60 (1 minute)."""
     return int(os.environ.get("RATE_LIMIT_WINDOW_SECONDS", "60"))

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -34,6 +34,9 @@ from config import (
     get_rate_limit_trusted_proxy_hops,
     get_rate_limit_unauth_max_requests,
     get_rate_limit_user_max_requests,
+    get_rate_limit_vault_max_requests,
+    get_rate_limit_vault_sensitive_max_requests,
+    get_rate_limit_vault_sensitive_window_seconds,
     get_rate_limit_window_seconds,
     get_sso_allow_private_networks,
 )
@@ -197,6 +200,9 @@ async def lifespan(app: FastAPI):
     app.state.rate_limit_user_max_requests = get_rate_limit_user_max_requests()
     app.state.rate_limit_unauth_max_requests = get_rate_limit_unauth_max_requests()
     app.state.rate_limit_auth_max_requests = get_rate_limit_auth_max_requests()
+    app.state.rate_limit_vault_max_requests = get_rate_limit_vault_max_requests()
+    app.state.rate_limit_vault_sensitive_max_requests = get_rate_limit_vault_sensitive_max_requests()
+    app.state.rate_limit_vault_sensitive_window_seconds = get_rate_limit_vault_sensitive_window_seconds()
     app.state.rate_limit_window_seconds = get_rate_limit_window_seconds()
     app.state.rate_limit_trusted_proxies = get_rate_limit_trusted_proxies()
     app.state.rate_limit_trusted_proxy_hops = get_rate_limit_trusted_proxy_hops()

--- a/server/src/security/rate_limit_middleware.py
+++ b/server/src/security/rate_limit_middleware.py
@@ -66,13 +66,13 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     )
 
     # Destructive vault operations throttled by a single GLOBAL bucket (all callers
-    # and all IPs share it), enforcing "at most once per window". This is what stops
-    # the DoS: an attacker cannot loop the anonymous `/vault/unlock/clear` to wipe
-    # accumulated shares, nor loop `/vault/setup` to overwrite a setup in progress —
-    # regardless of how many IPs they rotate through. Keyed by (method, exact path).
+    # and all IPs share it), enforcing "at most once per window" across both ops.
+    # This is what stops the DoS: an attacker cannot loop the anonymous
+    # `/vault/unlock/clear` to wipe accumulated shares, nor loop `/vault/setup` to
+    # overwrite a setup in progress — regardless of how many IPs they rotate through.
     VAULT_SENSITIVE_OPS: dict[tuple[str, str], str] = {
-        ("DELETE", "/api/vault/unlock/clear"): "vault:clear",
-        ("POST", "/api/vault/setup"): "vault:setup",
+        ("DELETE", "/api/vault/unlock/clear"): "vault:sensitive",
+        ("POST", "/api/vault/setup"): "vault:sensitive",
     }
 
     # Frequently-polled read-only endpoints that every page / pre-login flow hits:

--- a/server/src/security/rate_limit_middleware.py
+++ b/server/src/security/rate_limit_middleware.py
@@ -54,6 +54,27 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     # LoginLockoutGateway, not here.
     AUTH_ROUTES: tuple[str, ...] = ("/api/auth/login",)
 
+    # Vault-mutation endpoints share a strict per-IP floor. These are the
+    # (mostly unauthenticated) unlock/setup surfaces abused for DoS: looped
+    # `/vault/unlock/clear`, share-pool pollution via `/vault/unlock`, and
+    # `/vault/setup` re-init flooding. `/api/vault/unlock` covers both
+    # `/unlock` and `/unlock/clear`. `/api/vault/status` stays exempt (polled).
+    VAULT_MUTATION_PREFIXES: tuple[str, ...] = (
+        "/api/vault/unlock",
+        "/api/vault/setup",
+        "/api/vault/validate-setup",
+    )
+
+    # Destructive vault operations throttled by a single GLOBAL bucket (all callers
+    # and all IPs share it), enforcing "at most once per window". This is what stops
+    # the DoS: an attacker cannot loop the anonymous `/vault/unlock/clear` to wipe
+    # accumulated shares, nor loop `/vault/setup` to overwrite a setup in progress —
+    # regardless of how many IPs they rotate through. Keyed by (method, exact path).
+    VAULT_SENSITIVE_OPS: dict[tuple[str, str], str] = {
+        ("DELETE", "/api/vault/unlock/clear"): "vault:clear",
+        ("POST", "/api/vault/setup"): "vault:setup",
+    }
+
     # Frequently-polled read-only endpoints that every page / pre-login flow hits:
     # exempting them prevents the normal UI from burning through its IP bucket
     # on routine state checks.  Mutating or credential-submitting endpoints
@@ -89,6 +110,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             user_max = request.app.state.rate_limit_user_max_requests
             unauth_max = request.app.state.rate_limit_unauth_max_requests
             auth_max = request.app.state.rate_limit_auth_max_requests
+            vault_max = request.app.state.rate_limit_vault_max_requests
+            sensitive_max = request.app.state.rate_limit_vault_sensitive_max_requests
+            sensitive_window = request.app.state.rate_limit_vault_sensitive_window_seconds
             window = request.app.state.rate_limit_window_seconds
             trusted_proxies = request.app.state.rate_limit_trusted_proxies
             proxy_hops = request.app.state.rate_limit_trusted_proxy_hops
@@ -120,6 +144,38 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 )
                 return self._build_429_response(auth_result)
 
+        # Global throttle on destructive vault operations (clear / setup): a single
+        # shared bucket enforcing at-most-once-per-window across all callers. Checked
+        # before the per-IP floor so a throttled request consumes nothing else.
+        sensitive_key = self.VAULT_SENSITIVE_OPS.get((request.method, path))
+        if sensitive_key is not None:
+            sensitive_result = rate_limiter.check(sensitive_key, sensitive_max, sensitive_window, now=now)
+            if sensitive_result.is_limited:
+                logger.warning(
+                    "Rate limit exceeded: bucket=%s limit=%d path=%s %s",
+                    sensitive_key,
+                    sensitive_max,
+                    request.method,
+                    path,
+                )
+                return self._build_429_response(sensitive_result)
+
+        # Vault-mutation floor: a strict per-IP bucket in addition to the
+        # principal bucket, defeating the unauthenticated unlock/setup DoS
+        # vectors before they reach the (in-memory) share state.
+        if self._is_vault_mutation(path):
+            vault_key = f"ip:{client_ip}:vault"
+            vault_result = rate_limiter.check(vault_key, vault_max, window, now=now)
+            if vault_result.is_limited:
+                logger.warning(
+                    "Rate limit exceeded: bucket=%s limit=%d path=%s %s",
+                    vault_key,
+                    vault_max,
+                    request.method,
+                    path,
+                )
+                return self._build_429_response(vault_result)
+
         principal = self._resolve_principal(request, client_ip)
         if principal.kind == "user":
             principal_key = f"user:{principal.id}:api"
@@ -145,6 +201,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
     def _is_exempt(self, path: str) -> bool:
         return any(path.startswith(p) for p in self.EXEMPT_PREFIXES)
+
+    def _is_vault_mutation(self, path: str) -> bool:
+        return any(path.startswith(p) for p in self.VAULT_MUTATION_PREFIXES)
 
     @staticmethod
     def _resolve_principal(request: Request, client_ip: str) -> Principal:

--- a/server/src/security/rate_limit_middleware.py
+++ b/server/src/security/rate_limit_middleware.py
@@ -136,7 +136,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             auth_result = rate_limiter.check(auth_key, auth_max, window, now=now)
             if auth_result.is_limited:
                 logger.warning(
-                    "Rate limit exceeded: bucket=%s limit=%d path=%s %s",
+                    "Rate limit exceeded: bucket=%s limit=%d method=%s path=%s",
                     auth_key,
                     auth_max,
                     request.method,
@@ -152,7 +152,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             sensitive_result = rate_limiter.check(sensitive_key, sensitive_max, sensitive_window, now=now)
             if sensitive_result.is_limited:
                 logger.warning(
-                    "Rate limit exceeded: bucket=%s limit=%d path=%s %s",
+                    "Rate limit exceeded: bucket=%s limit=%d method=%s path=%s",
                     sensitive_key,
                     sensitive_max,
                     request.method,
@@ -168,7 +168,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             vault_result = rate_limiter.check(vault_key, vault_max, window, now=now)
             if vault_result.is_limited:
                 logger.warning(
-                    "Rate limit exceeded: bucket=%s limit=%d path=%s %s",
+                    "Rate limit exceeded: bucket=%s limit=%d method=%s path=%s",
                     vault_key,
                     vault_max,
                     request.method,
@@ -186,7 +186,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         principal_result = rate_limiter.check(principal_key, principal_limit, window, now=now)
         if principal_result.is_limited:
             logger.warning(
-                "Rate limit exceeded: bucket=%s limit=%d path=%s %s",
+                "Rate limit exceeded: bucket=%s limit=%d method=%s path=%s",
                 principal_key,
                 principal_limit,
                 request.method,

--- a/server/src/vault_management_context/adapters/secondary/in_memory_share_repository.py
+++ b/server/src/vault_management_context/adapters/secondary/in_memory_share_repository.py
@@ -1,12 +1,17 @@
+import logging
 from datetime import datetime, timezone
 
 from vault_management_context.application.gateways import ShareRepository
 from vault_management_context.domain.entities import Share
 
+logger = logging.getLogger(__name__)
+
 # Hard cap on the number of pending unlock shares held in memory. Legitimate
 # accumulation never exceeds the vault's share count (a handful); the cap bounds
 # memory against an anonymous flood on the unauthenticated /vault/unlock endpoint.
 # (Deduplication is a domain concern enforced upstream in UnlockVaultUseCase.)
+# When full, newly submitted shares are dropped rather than evicting existing ones:
+# eviction would let an attacker flush already-submitted legitimate shares.
 MAX_PENDING_SHARES = 64
 
 
@@ -19,13 +24,25 @@ class InMemoryShareRepository(ShareRepository):
         return self._shares.copy()
 
     def add(self, shares: list[Share]) -> None:
-        added = False
+        accepted = 0
         for share in shares:
             if len(self._shares) >= MAX_PENDING_SHARES:
                 break  # cap: bound memory against a flood
             self._shares.append(share)
-            added = True
-        if added:
+            accepted += 1
+
+        dropped = len(shares) - accepted
+        if dropped:
+            # Surface the (rare) cap hit — likely a share-pool flood. An operator
+            # can clear the pending shares to let legitimate submissions through.
+            logger.warning(
+                "Pending unlock-share pool at capacity (%d); dropped %d submitted share(s). "
+                "Possible flood on /vault/unlock — clear pending shares to recover.",
+                MAX_PENDING_SHARES,
+                dropped,
+            )
+
+        if accepted:
             self._last_share_timestamp = datetime.now(timezone.utc)
 
     def clear(self) -> None:

--- a/server/src/vault_management_context/adapters/secondary/in_memory_share_repository.py
+++ b/server/src/vault_management_context/adapters/secondary/in_memory_share_repository.py
@@ -3,6 +3,12 @@ from datetime import datetime, timezone
 from vault_management_context.application.gateways import ShareRepository
 from vault_management_context.domain.entities import Share
 
+# Hard cap on the number of pending unlock shares held in memory. Legitimate
+# accumulation never exceeds the vault's share count (a handful); the cap bounds
+# memory against an anonymous flood on the unauthenticated /vault/unlock endpoint.
+# (Deduplication is a domain concern enforced upstream in UnlockVaultUseCase.)
+MAX_PENDING_SHARES = 64
+
 
 class InMemoryShareRepository(ShareRepository):
     def __init__(self):
@@ -13,8 +19,14 @@ class InMemoryShareRepository(ShareRepository):
         return self._shares.copy()
 
     def add(self, shares: list[Share]) -> None:
-        self._shares.extend(shares)
-        self._last_share_timestamp = datetime.now(timezone.utc)
+        added = False
+        for share in shares:
+            if len(self._shares) >= MAX_PENDING_SHARES:
+                break  # cap: bound memory against a flood
+            self._shares.append(share)
+            added = True
+        if added:
+            self._last_share_timestamp = datetime.now(timezone.utc)
 
     def clear(self) -> None:
         self._shares = []

--- a/server/src/vault_management_context/application/gateways/share_repository.py
+++ b/server/src/vault_management_context/application/gateways/share_repository.py
@@ -7,8 +7,9 @@ from vault_management_context.domain.entities import Share
 class ShareRepository(Protocol):
     """Store for the pending unlock shares accumulated before reconstruction.
 
-    A dumb sink: deduplication of shares is a domain concern enforced upstream by
-    ``UnlockVaultUseCase``; implementations only persist and return what they are given.
+    A dumb sink regarding *deduplication*: deduplication of shares is enforced upstream by
+    ``UnlockVaultUseCase``; repository implementations persist and return what they are given,
+    but may still apply storage limits (e.g., an in-memory cap) to bound resource usage.
     """
 
     def get_all(self) -> list[Share]: ...

--- a/server/src/vault_management_context/application/gateways/share_repository.py
+++ b/server/src/vault_management_context/application/gateways/share_repository.py
@@ -5,6 +5,12 @@ from vault_management_context.domain.entities import Share
 
 
 class ShareRepository(Protocol):
+    """Store for the pending unlock shares accumulated before reconstruction.
+
+    A dumb sink: deduplication of shares is a domain concern enforced upstream by
+    ``UnlockVaultUseCase``; implementations only persist and return what they are given.
+    """
+
     def get_all(self) -> list[Share]: ...
 
     def add(self, shares: list[Share]) -> None: ...

--- a/server/src/vault_management_context/application/use_cases/unlock_vault_use_case.py
+++ b/server/src/vault_management_context/application/use_cases/unlock_vault_use_case.py
@@ -12,6 +12,7 @@ from vault_management_context.application.gateways import (
     VaultSessionGateway,
 )
 from vault_management_context.application.services import KeySessionManager
+from vault_management_context.domain.entities import Share
 from vault_management_context.domain.events import VaultUnlockedEvent
 from vault_management_context.domain.exceptions import (
     ShareReconstructionError,
@@ -46,10 +47,14 @@ class UnlockVaultUseCase(TracedUseCase):
         if vault is None:
             raise VaultNotSetupException()
 
-        try:
-            existing_shares = self._share_repository.get_all()
-            all_shares = existing_shares + command.shares
+        existing_shares = self._share_repository.get_all()
+        # Domain invariant: a share must not count twice toward the threshold.
+        # Dedupe the submission against the already-pending pool (and against
+        # itself) here, in the application layer, so the store stays a dumb sink.
+        new_shares = self._deduplicate(command.shares, existing_shares)
+        all_shares = existing_shares + new_shares
 
+        try:
             master_secret = self._shamir_gateway.reconstruct_secret(all_shares)
 
             KeySessionManager.decrypt_and_store_key(
@@ -73,5 +78,15 @@ class UnlockVaultUseCase(TracedUseCase):
         except VaultUnlockedError as e:
             raise e
         except Exception as e:
-            self._share_repository.add(command.shares)
+            self._share_repository.add(new_shares)
             raise ShareReconstructionError() from e
+
+    @staticmethod
+    def _deduplicate(new_shares: list[Share], existing_shares: list[Share]) -> list[Share]:
+        seen = {share.secret for share in existing_shares}
+        deduped: list[Share] = []
+        for share in new_shares:
+            if share.secret not in seen:
+                deduped.append(share)
+                seen.add(share.secret)
+        return deduped

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -40,6 +40,10 @@ def env_vars():
     os.environ["RATE_LIMIT_USER_MAX_REQUESTS"] = "10000"
     os.environ["RATE_LIMIT_UNAUTH_MAX_REQUESTS"] = "10000"
     os.environ["RATE_LIMIT_AUTH_MAX_REQUESTS"] = "10000"
+    os.environ["RATE_LIMIT_VAULT_MAX_REQUESTS"] = "10000"
+    # Neutralize the "once per minute" global throttle on destructive vault ops so the
+    # vault workflow can perform several clears/setups back-to-back within one test.
+    os.environ["RATE_LIMIT_VAULT_SENSITIVE_MAX_REQUESTS"] = "10000"
     # Shorten the lockout window so PHASE 7 can exercise the lock→wait→retry
     # cycle end-to-end without making the suite sleep for minutes. The default
     # (5 failures / 300s) is preserved in production; tests only care that the
@@ -56,6 +60,8 @@ def env_vars():
         "RATE_LIMIT_USER_MAX_REQUESTS",
         "RATE_LIMIT_UNAUTH_MAX_REQUESTS",
         "RATE_LIMIT_AUTH_MAX_REQUESTS",
+        "RATE_LIMIT_VAULT_MAX_REQUESTS",
+        "RATE_LIMIT_VAULT_SENSITIVE_MAX_REQUESTS",
         "LOGIN_LOCKOUT_SECONDS",
         "SSO_ALLOW_PRIVATE_NETWORKS",
     ):

--- a/server/tests/security/unit/test_rate_limit_middleware.py
+++ b/server/tests/security/unit/test_rate_limit_middleware.py
@@ -342,6 +342,15 @@ def test_given_clear_throttle_is_global_across_ips():
         assert c.delete("/api/vault/unlock/clear", headers={"X-Forwarded-For": "203.0.113.2"}).status_code == 429
 
 
+def test_given_clear_and_setup_share_the_same_global_bucket():
+    # clear and setup contend for ONE bucket, so a clear consumes the window for a
+    # subsequent setup (at most one destructive op per window across both routes).
+    app = _create_app(user_max=100, unauth_max=100, vault_max=100, sensitive_max=1, sensitive_window=60)
+    with TestClient(app) as c:
+        assert c.delete("/api/vault/unlock/clear").status_code == 200
+        assert c.post("/api/vault/setup", json={"nb_shares": 3, "threshold": 2}).status_code == 429
+
+
 def test_given_unlock_when_flooded_should_not_consume_global_throttle():
     # Submitting shares (the anonymous multi-party path) must never be throttled by
     # the destructive-op bucket.

--- a/server/tests/security/unit/test_rate_limit_middleware.py
+++ b/server/tests/security/unit/test_rate_limit_middleware.py
@@ -41,6 +41,9 @@ def _create_app(
     user_max: int = 300,
     unauth_max: int = 30,
     auth_max: int = 100,
+    vault_max: int = 10,
+    sensitive_max: int = 1,
+    sensitive_window: int = 60,
     window: int = 60,
     login_status_code: int = 401,
     token_gateway: _FakeTokenGateway | None = None,
@@ -56,6 +59,9 @@ def _create_app(
     app.state.rate_limit_user_max_requests = user_max
     app.state.rate_limit_unauth_max_requests = unauth_max
     app.state.rate_limit_auth_max_requests = auth_max
+    app.state.rate_limit_vault_max_requests = vault_max
+    app.state.rate_limit_vault_sensitive_max_requests = sensitive_max
+    app.state.rate_limit_vault_sensitive_window_seconds = sensitive_window
     app.state.rate_limit_window_seconds = window
     app.state.rate_limit_trusted_proxies = trusted_proxies if trusted_proxies is not None else {"127.0.0.1", "::1"}
     app.state.rate_limit_trusted_proxy_hops = trusted_proxy_hops
@@ -97,6 +103,18 @@ def _create_app(
     @app.get("/vault/status")
     async def vault_status():
         return PlainTextResponse("status", status_code=200)
+
+    @app.post("/vault/unlock")
+    async def vault_unlock():
+        return PlainTextResponse("unlock", status_code=202)
+
+    @app.delete("/vault/unlock/clear")
+    async def vault_clear():
+        return PlainTextResponse("clear", status_code=200)
+
+    @app.post("/vault/setup")
+    async def vault_setup():
+        return PlainTextResponse("setup", status_code=201)
 
     @app.get("/other")
     async def other():
@@ -277,6 +295,60 @@ def test_given_access_token_raises_unexpected_error_when_dispatching_should_fall
     warnings = [rec for rec in caplog.records if rec.levelname == "WARNING" and "Token gateway" in rec.getMessage()]
     assert warnings, "Unexpected token-gateway errors must surface at WARNING"
     assert warnings[0].exc_info is not None, "WARNING must include exc_info for Sentry grouping"
+
+
+# ── Vault-mutation floor (per-IP) ─────────────────────────────────────
+
+
+def test_given_vault_unlock_flood_when_dispatching_should_apply_vault_floor():
+    # /unlock is not a "sensitive op" (no global throttle); only the per-IP floor applies.
+    app = _create_app(user_max=100, unauth_max=100, vault_max=3, window=60)
+    with TestClient(app) as c:
+        for _ in range(3):
+            assert c.post("/api/vault/unlock", json={"shares": ["x"]}).status_code == 202
+        assert c.post("/api/vault/unlock", json={"shares": ["x"]}).status_code == 429
+
+
+def test_given_vault_status_when_flooded_should_stay_exempt():
+    app = _create_app(user_max=100, unauth_max=100, vault_max=1, window=60)
+    with TestClient(app) as c:
+        for _ in range(5):
+            assert c.get("/api/vault/status").status_code == 200
+
+
+# ── Global destructive-op throttle (clear / setup, once per window) ───
+
+
+def test_given_clear_second_call_within_window_should_hit_global_throttle():
+    app = _create_app(user_max=100, unauth_max=100, vault_max=100, sensitive_max=1, sensitive_window=60)
+    with TestClient(app) as c:
+        assert c.delete("/api/vault/unlock/clear").status_code == 200
+        assert c.delete("/api/vault/unlock/clear").status_code == 429
+
+
+def test_given_setup_second_call_within_window_should_hit_global_throttle():
+    app = _create_app(user_max=100, unauth_max=100, vault_max=100, sensitive_max=1, sensitive_window=60)
+    with TestClient(app) as c:
+        assert c.post("/api/vault/setup", json={"nb_shares": 3, "threshold": 2}).status_code == 201
+        assert c.post("/api/vault/setup", json={"nb_shares": 3, "threshold": 2}).status_code == 429
+
+
+def test_given_clear_throttle_is_global_across_ips():
+    # A single shared bucket: a second clear from a DIFFERENT IP is still throttled,
+    # so rotating IPs does not bypass the once-per-window limit.
+    app = _create_app(user_max=100, unauth_max=100, vault_max=100, sensitive_max=1, trusted_proxies={"testclient"})
+    with TestClient(app) as c:
+        assert c.delete("/api/vault/unlock/clear", headers={"X-Forwarded-For": "203.0.113.1"}).status_code == 200
+        assert c.delete("/api/vault/unlock/clear", headers={"X-Forwarded-For": "203.0.113.2"}).status_code == 429
+
+
+def test_given_unlock_when_flooded_should_not_consume_global_throttle():
+    # Submitting shares (the anonymous multi-party path) must never be throttled by
+    # the destructive-op bucket.
+    app = _create_app(user_max=100, unauth_max=100, vault_max=100, sensitive_max=1)
+    with TestClient(app) as c:
+        for _ in range(5):
+            assert c.post("/api/vault/unlock", json={"shares": ["x"]}).status_code == 202
 
 
 # ── Auth-route floor (login only) ─────────────────────────────────────

--- a/server/tests/vault_management_context/unit/test_in_memory_share_repository.py
+++ b/server/tests/vault_management_context/unit/test_in_memory_share_repository.py
@@ -1,3 +1,5 @@
+import logging
+
 from vault_management_context.adapters.secondary.in_memory_share_repository import (
     MAX_PENDING_SHARES,
     InMemoryShareRepository,
@@ -10,6 +12,17 @@ def test_should_cap_pending_shares_to_bound_memory():
 
     repo.add([Share(f"{i}:x") for i in range(MAX_PENDING_SHARES + 25)])
 
+    assert len(repo.get_all()) == MAX_PENDING_SHARES
+
+
+def test_should_warn_when_dropping_shares_at_capacity(caplog):
+    repo = InMemoryShareRepository()
+    repo.add([Share(f"{i}:x") for i in range(MAX_PENDING_SHARES)])
+
+    with caplog.at_level(logging.WARNING):
+        repo.add([Share("extra:1"), Share("extra:2")])
+
+    assert "at capacity" in caplog.text
     assert len(repo.get_all()) == MAX_PENDING_SHARES
 
 

--- a/server/tests/vault_management_context/unit/test_in_memory_share_repository.py
+++ b/server/tests/vault_management_context/unit/test_in_memory_share_repository.py
@@ -1,0 +1,22 @@
+from vault_management_context.adapters.secondary.in_memory_share_repository import (
+    MAX_PENDING_SHARES,
+    InMemoryShareRepository,
+)
+from vault_management_context.domain.entities import Share
+
+
+def test_should_cap_pending_shares_to_bound_memory():
+    repo = InMemoryShareRepository()
+
+    repo.add([Share(f"{i}:x") for i in range(MAX_PENDING_SHARES + 25)])
+
+    assert len(repo.get_all()) == MAX_PENDING_SHARES
+
+
+def test_should_append_without_deduplicating():
+    # The store is a dumb sink: deduplication is the use case's responsibility.
+    repo = InMemoryShareRepository()
+
+    repo.add([Share("0:a"), Share("0:a")])
+
+    assert len(repo.get_all()) == 2

--- a/server/tests/vault_management_context/unit/use_cases/test_unlock_vault_use_case.py
+++ b/server/tests/vault_management_context/unit/use_cases/test_unlock_vault_use_case.py
@@ -259,6 +259,28 @@ def test_given_insufficient_shares_when_unlocking_fails_should_add_shares_to_rep
     assert stored_shares[0].secret == "share0"
 
 
+def test_given_duplicate_share_when_unlocking_should_not_count_it_twice(
+    use_case,
+    vault_repository: FakeVaultRepository,
+    share_repository: FakeShareRepository,
+):
+    vault_repository.save_vault_with_shares(nb_shares=3, threshold=2)
+    share_repository.add([Share("0:aa")])  # already pending
+
+    # Resubmit the already-pending share plus a new one; reconstruction fails
+    # (no shamir result configured), so the deduped new share is stored.
+    with pytest.raises(ShareReconstructionError):
+        use_case.execute(UnlockVaultCommand(shares=[Share("0:aa"), Share("1:bb")]))
+
+    assert sorted(s.secret for s in share_repository.get_all()) == ["0:aa", "1:bb"]
+
+    # Resubmitting only the duplicate adds nothing.
+    with pytest.raises(ShareReconstructionError):
+        use_case.execute(UnlockVaultCommand(shares=[Share("0:aa")]))
+
+    assert len(share_repository.get_all()) == 2
+
+
 def test_given_valid_shares_when_unlocking_vault_should_store_vault_unlocked_event(
     use_case,
     vault_repository: FakeVaultRepository,


### PR DESCRIPTION
## Description

Mitigates **AUTHZ-VULN-11** — an unauthenticated DoS on the vault-unlock flow.

Previously, anonymous callers could:
- loop `DELETE /api/vault/unlock/clear` to wipe the accumulated Shamir shares, so
  the vault could never reach its unlock threshold;
- loop `POST /api/vault/setup` while a setup was `PENDING` to overwrite it.

Unlocking must stay **anonymous and multi-party** (each shareholder submits their
share independently), so instead of adding authentication we bound the abusable
operations in time:

- **Global throttle (once per minute)** on the two destructive endpoints
  `DELETE /api/vault/unlock/clear` and `POST /api/vault/setup` — a single shared
  bucket across all callers/IPs, so rotating IPs does not help. Enforced in
  `RateLimitMiddleware`.
- **Per-IP floor** on every vault mutation endpoint (`/unlock`, `/unlock/clear`,
  `/setup`, `/validate-setup`), default 30/min.
- **Dedup + cap** of the in-memory pending-share pool (a resubmitted share is not
  counted twice; the pool size is bounded).
- New env vars documented in `.env.example` / `server/.env.example`:
  `RATE_LIMIT_VAULT_MAX_REQUESTS` (30), `RATE_LIMIT_VAULT_SENSITIVE_MAX_REQUESTS`
  (1), `RATE_LIMIT_VAULT_SENSITIVE_WINDOW_SECONDS` (60).

`POST /api/vault/unlock` (share submission) is intentionally **never** throttled by
the global bucket.

> ⚠️ **Deliberate trade-off:** this is a *temporal mitigation*, not full
> elimination. Without authentication, a determined attacker can still trigger a
> clear/setup once per minute; the throttle + per-IP floor make the DoS
> impractical while preserving the anonymous, dependency-free unlock ceremony.

No route/model signatures changed → the generated OpenAPI client is unaffected. No
DB migration.

## Related Issues
- Fixes #<!-- numéro de l'issue AUTHZ-VULN-11 si tu en as une -->

## Checklist
- [x] I have tested the changes locally.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have ensured that my code follows the project's coding standards.
