### PR TITLE
fix(deps): bump click 8.3.2 -> 8.4.2 to clear PYSEC-2026-2132

### DIFF
--- a/server/uv.lock
+++ b/server/uv.lock
@@ -290,14 +290,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.2"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# fix(deps): bump click 8.3.2 -> 8.4.2 to clear PYSEC-2026-2132

## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
Unblocks the `back-ci` **Check Dependencies Security** gate, which fails on:

```
click 8.3.2: PYSEC-2026-2132 -> fix available: 8.3.3
```

The gate only fails on vulnerabilities that report a non-empty `fix_versions` - unfixable ones are tolerated by design. A fix exists here, so CI stays red until `click` moves.

**Severity in this codebase: low.** [PYSEC-2026-2132](https://osv.dev/vulnerability/PYSEC-2026-2132) (CVE-2026-7246, GHSA-47fr-3ffg-hgmw) is a command injection in `click.edit()`: **local** attack vector, high complexity, user interaction required. The server never imports `click` and never calls `click.edit()`. `click` is a **purely transitive** dependency:

| Consumer | Reached via | Declared constraint |
|---|---|---|
| `uvicorn` 0.44.0 | `fastapi[standard]` | `click>=7.0` |
| `typer` 0.24.1 | `fastapi[standard]` | `click>=8.2.1` |
| `rich-toolkit` 0.19.7 | `fastapi[standard]` | `click>=8.1.7` |
| `flask` 3.1.3 | `oidc-provider-mock` (dev group) | `click>=8.1.3` |
| `sqlite-utils` 3.39 | `sqlite` extra | `click>=8.3.1` |
| `click-default-group` 1.2.4 | `sqlite-utils` | `click` |

This is a CI unblock, not a fix for a live exposure.

Changes:
- **`server/uv.lock`**  `click` 8.3.2 -> **8.4.2**, via `uv lock --upgrade-package click`. No consumer caps `click` and `pyproject.toml` never mentions it, so resolution goes straight to the latest release with no constraint work needed.

Lockfile-only; `pyproject.toml` untouched and no other package changes version -> 3-line diff in a single file. No migration, no API surface change.


## Checklist
- [x] I have tested the changes locally.
- [ ]  I have added tests that prove my fix is effective or that my feature works. (no tests needed)
- [x] I have ensured that my code follows the project's coding standards.

## Verification
Run from `server/`:

1. **CI gate replayed locally** - `uv export --format requirements-txt --no-hashes > /tmp/requirements.txt && uvx pip-audit -r /tmp/requirements.txt` -> `No known vulnerabilities found`, no `click` line.
2. **Lock consistency** - `uv sync --frozen --group monitoring` succeeds (what CI runs just before the audit).
3. **No regression** - `uv run pytest` -> **639 passed**. The `e2e` profile boots the full FastAPI app, exercising the `uvicorn`/`typer` CLI - the only place a minor `click` bump could surface.
