### PR TITLE
security: enforce CSRF on the SSO configure endpoint (AUTH-VULN-05)

### DIFF
--- a/server/src/security/csrf_middleware.py
+++ b/server/src/security/csrf_middleware.py
@@ -31,14 +31,18 @@ class CsrfMiddleware(BaseHTTPMiddleware):
     CSRF protection middleware using the Synchronizer Token Pattern.
 
     Validates CSRF tokens on mutating requests (POST, PUT, DELETE, PATCH).
-    Exempt routes include SSO endpoints and refresh token endpoint.
+    Exempt routes are those reached before a CSRF token can exist (login,
+    registration, refresh, vault bootstrap/unlock).
 
     The token must be sent in the 'X-CSRF-Token' header.
     """
 
-    # Routes that are exempt from CSRF protection
+    # Routes that are exempt from CSRF protection.
+    # Note: SSO routes are deliberately NOT exempt. Its read endpoints (url,
+    # callback, is-configured) are GETs and are skipped by the method check
+    # anyway, while /api/auth/sso/configure is an authenticated admin POST that
+    # must carry a CSRF token — defense in depth on top of SameSite=strict.
     EXEMPT_ROUTES = [
-        "/api/auth/sso",  # All SSO routes (callback, url, configure)
         "/api/auth/refresh-token",
         "/api/auth/login",  # Login generates the token, can't require it
         "/api/auth/register-admin",  # Registration happens before token exists

--- a/server/tests/e2e/test_complete_authentication_workflow.py
+++ b/server/tests/e2e/test_complete_authentication_workflow.py
@@ -308,6 +308,11 @@ async def test_complete_authentication_workflow(
     print("🔗 PHASE 5: SSO AUTHENTICATION")
     print("=" * 80)
 
+    # PHASE 4 rotated the CSRF token server-side (step 4.8), leaving the client's
+    # cached one stale. Resync it: /auth/sso/configure is a CSRF-protected admin POST
+    # and the steps below rely on the client's automatic token injection.
+    e2e_client.refresh_csrf_token()
+
     # Step 5.1: Check SSO status before configuration
     print("\n📊 Step 5.1: Checking SSO status before configuration...")
     status_before_response = e2e_client.get("/api/auth/sso/is-configured")

--- a/server/tests/e2e/test_sso_security.py
+++ b/server/tests/e2e/test_sso_security.py
@@ -31,3 +31,31 @@ def test_sso_callback_with_mismatched_state_is_rejected(e2e_client, configured_s
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Invalid SSO state"
+
+
+_CONFIGURE_BODY = {
+    "client_id": "x",
+    "client_secret": "x",
+    "discovery_url": "https://idp.example.com/.well-known/openid-configuration",
+}
+
+
+def test_sso_configure_requires_a_csrf_token(authenticated_admin_client):
+    # SSO routes are no longer blanket CSRF-exempt: the authenticated admin POST
+    # must carry X-CSRF-Token (defense in depth on top of SameSite=strict).
+    authenticated_admin_client.disable_auto_csrf()
+    try:
+        response = authenticated_admin_client.post("/api/auth/sso/configure", json=_CONFIGURE_BODY)
+    finally:
+        authenticated_admin_client.enable_auto_csrf()
+
+    assert response.status_code == 403
+    assert "CSRF token missing" in response.json()["detail"]
+
+
+def test_sso_configure_without_auth_still_returns_401(unauthenticated_client):
+    # Unchanged behaviour: with no session there is no CSRF token to check, so the
+    # middleware defers and the route answers 401 (not 403).
+    response = unauthenticated_client.post("/api/auth/sso/configure", json=_CONFIGURE_BODY)
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Description

**AUTH-VULN-05** (OAuth `state` generated then discarded → login CSRF / session
fixation) is **already fixed and covered by regression tests** — it shipped with the
SSO PR:

| Recommendation | Status |
|---|---|
| Cryptographically random state | ✅ `secrets.token_urlsafe(32)` |
| Stored at issuance (httpOnly cookie) | ✅ `sso_state`, httpOnly, `SameSite=Lax`, 600s TTL |
| Compared at callback **before** the code exchange | ✅ `secrets.compare_digest` → 400 |
| Single use | ✅ cookie cleared after use |
| Regression tests | ✅ `tests/e2e/test_sso_security.py` |
| OIDC nonce | ⚠️ **N/A** — see below |

**Why no nonce:** the nonce binds an **ID token** to the authorization request. This
flow never consumes `id_token`: it exchanges the code server-side and reads claims
from the **userinfo** endpoint. With no ID token validation there is no replay vector
for a nonce to close.

This PR therefore only addresses the **adjacent issue** the finding calls out ("SSO
routes are CSRF-exempt"): `CsrfMiddleware` blanket-exempted `/api/auth/sso`, so
`/auth/sso/configure` — an **authenticated admin POST** that overwrites the SSO
provider configuration — was protected by `SameSite=strict` alone. This adds
defense in depth.

### Blast radius: exactly one endpoint

- There are 4 SSO routes: `url`, `callback`, `is-configured` (**GET**) and
  `configure` (**POST**).
- The middleware skips non-mutating methods **before** the exemption check, so the
  exemption was a no-op for the three GETs — removing it changes nothing for them.
- The middleware also skips when there is no `access_token` cookie, so an
  **unauthenticated** `configure` still returns **401** (not 403) — unchanged, and
  now pinned by a test.
- Net effect: **authenticated `POST /auth/sso/configure` now requires `X-CSRF-Token`.**

No change to the CSRF validation logic, the 403 responses, the token manager, or the
other exemptions (`refresh-token`, `login`, `register-admin`, vault bootstrap/unlock).

**No frontend impact:** `customClient.ts` attaches `X-CSRF-Token` to every mutating
request with no path exclusions, and the SSO configure call goes through the
generated SDK → the interceptor. Proven by the e2e auth workflow, which configures
SSO with CSRF enforced.


## Checklist
- [x] I have tested the changes locally.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have ensured that my code follows the project's coding standards.