### PR TITLE
security: enforce a password policy on IAM credentials (AUTH-VULN-08)

### DIFF
--- a/frontend/src/components/modals/CreateUserModal.vue
+++ b/frontend/src/components/modals/CreateUserModal.vue
@@ -83,12 +83,12 @@ const handleSubmit = async () => {
     return
   }
 
-  // Must stay in sync with the server policy (MIN_PASSWORD_LENGTH = 12).
-  if (password.value.length < 12) {
+  // Must stay in sync with the server policy (MIN_PASSWORD_LENGTH = 15).
+  if (password.value.length < 15) {
     toast.add({
       severity: 'error',
       summary: 'Validation Error',
-      detail: 'Password must be at least 12 characters long',
+      detail: 'Password must be at least 15 characters long',
       life: 5000,
     })
     return

--- a/frontend/src/components/modals/CreateUserModal.vue
+++ b/frontend/src/components/modals/CreateUserModal.vue
@@ -83,6 +83,17 @@ const handleSubmit = async () => {
     return
   }
 
+  // Must stay in sync with the server policy (MIN_PASSWORD_LENGTH = 12).
+  if (password.value.length < 12) {
+    toast.add({
+      severity: 'error',
+      summary: 'Validation Error',
+      detail: 'Password must be at least 12 characters long',
+      life: 5000,
+    })
+    return
+  }
+
   try {
     loading.value = true
 

--- a/frontend/src/components/setup/StepAdminAccountForm.vue
+++ b/frontend/src/components/setup/StepAdminAccountForm.vue
@@ -34,15 +34,15 @@ const resolver = ref(
     z
       .object({
         email: z.email({ message: 'Invalid email address.' }),
-        // Must stay in sync with the server policy (MIN_PASSWORD_LENGTH = 12),
+        // Must stay in sync with the server policy (MIN_PASSWORD_LENGTH = 15),
         // otherwise the form passes here and the API answers 400.
-        password: z.string().min(12, { message: 'Password must be at least 12 characters long.' }),
+        password: z.string().min(15, { message: 'Password must be at least 15 characters long.' }),
         display_name: z
           .string()
           .min(2, { message: 'Display name must be at least 2 characters long.' }),
         confirm_password: z
           .string()
-          .min(12, { message: 'Confirm password must be at least 12 characters long.' }),
+          .min(15, { message: 'Confirm password must be at least 15 characters long.' }),
       })
       .refine((data) => data.password === data.confirm_password, {
         message: 'Passwords do not match.',

--- a/frontend/src/components/setup/StepAdminAccountForm.vue
+++ b/frontend/src/components/setup/StepAdminAccountForm.vue
@@ -34,13 +34,15 @@ const resolver = ref(
     z
       .object({
         email: z.email({ message: 'Invalid email address.' }),
-        password: z.string().min(6, { message: 'Password must be at least 6 characters long.' }),
+        // Must stay in sync with the server policy (MIN_PASSWORD_LENGTH = 12),
+        // otherwise the form passes here and the API answers 400.
+        password: z.string().min(12, { message: 'Password must be at least 12 characters long.' }),
         display_name: z
           .string()
           .min(2, { message: 'Display name must be at least 2 characters long.' }),
         confirm_password: z
           .string()
-          .min(6, { message: 'Confirm password must be at least 6 characters long.' }),
+          .min(12, { message: 'Confirm password must be at least 12 characters long.' }),
       })
       .refine((data) => data.password === data.confirm_password, {
         message: 'Passwords do not match.',

--- a/server/src/identity_access_management_context/adapters/primary/fastapi/routes/admin/register_admin_with_password_route.py
+++ b/server/src/identity_access_management_context/adapters/primary/fastapi/routes/admin/register_admin_with_password_route.py
@@ -13,6 +13,7 @@ from identity_access_management_context.application.use_cases import (
 )
 from identity_access_management_context.domain.exceptions import (
     AdminAlreadyExistsException,
+    IdentityAccessManagementDomainError,
 )
 
 logger = logging.getLogger(__name__)
@@ -73,6 +74,8 @@ def register_admin(
 
     except AdminAlreadyExistsException as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
+    except IdentityAccessManagementDomainError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         logger.exception("Unexpected error in register admin")
         raise HTTPException(status_code=500, detail="Internal server error") from e

--- a/server/src/identity_access_management_context/application/use_cases/create_user_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/create_user_use_case.py
@@ -12,6 +12,7 @@ from identity_access_management_context.application.gateways import (
 from identity_access_management_context.application.services import UserCreationService
 from identity_access_management_context.domain.entities import User, UserPassword
 from identity_access_management_context.domain.events import UserCreatedEvent
+from identity_access_management_context.domain.value_objects import RawPassword
 from shared_kernel.application.gateways import DomainEventPublisher
 from shared_kernel.application.tracing import TracedUseCase
 from shared_kernel.domain.services import AdminPermissionChecker
@@ -39,6 +40,10 @@ class CreateUserUseCase(TracedUseCase):
     def execute(self, command: CreateUserCommand) -> UUID:
         AdminPermissionChecker().ensure_admin(command.requesting_user, "Create User")
 
+        # Must run before the User is saved below: a late failure would leave an
+        # orphaned User row with no UserPassword.
+        password = RawPassword(command.password)
+
         user = User(
             id=command.id,
             username=command.username,
@@ -48,7 +53,7 @@ class CreateUserUseCase(TracedUseCase):
 
         self.user_repository.save(user)
 
-        password_hash = self.password_hashing_gateway.hash(command.password)
+        password_hash = self.password_hashing_gateway.hash(password.value)
 
         user_password = UserPassword(
             id=command.id,

--- a/server/src/identity_access_management_context/application/use_cases/register_admin_with_password_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/register_admin_with_password_use_case.py
@@ -20,6 +20,7 @@ from identity_access_management_context.domain.events import AdminRegisteredEven
 from identity_access_management_context.domain.exceptions import (
     AdminAlreadyExistsException,
 )
+from identity_access_management_context.domain.value_objects import RawPassword
 from shared_kernel.application.gateways import DomainEventPublisher
 from shared_kernel.application.tracing import TracedUseCase
 
@@ -44,6 +45,10 @@ class RegisterAdminWithPasswordUseCase(TracedUseCase):
         self._admin_event_repository = admin_event_repository
 
     def execute(self, command: RegisterAdminWithPasswordCommand) -> UUID:
+        # Enforce the account-password policy before any work: constructing the value
+        # object raises a PasswordPolicyViolationError on a weak password.
+        password = RawPassword(command.password)
+
         # All operations are synchronous DB/CPU work — run in a thread pool to
         # avoid blocking the event loop.
         def _run() -> UUID:
@@ -52,7 +57,7 @@ class RegisterAdminWithPasswordUseCase(TracedUseCase):
             if not user_management_service.can_create_admin():
                 raise AdminAlreadyExistsException("An admin account already exists")
 
-            password_hash = self._password_hashing_gateway.hash(command.password)
+            password_hash = self._password_hashing_gateway.hash(password.value)
             user_password = UserPassword(
                 id=command.id,
                 email=command.email,

--- a/server/src/identity_access_management_context/application/use_cases/register_admin_with_password_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/register_admin_with_password_use_case.py
@@ -49,8 +49,7 @@ class RegisterAdminWithPasswordUseCase(TracedUseCase):
         # object raises a PasswordPolicyViolationError on a weak password.
         password = RawPassword(command.password)
 
-        # All operations are synchronous DB/CPU work — run in a thread pool to
-        # avoid blocking the event loop.
+        # All operations are synchronous DB/CPU work.
         def _run() -> UUID:
             user_management_service = UserManagementService(self._user_repository, self._password_hashing_gateway)
 

--- a/server/src/identity_access_management_context/application/use_cases/update_user_password_use_case.py
+++ b/server/src/identity_access_management_context/application/use_cases/update_user_password_use_case.py
@@ -9,6 +9,7 @@ from identity_access_management_context.domain.exceptions import (
     InvalidCredentialsException,
     UserNotFoundException,
 )
+from identity_access_management_context.domain.value_objects import RawPassword
 from shared_kernel.application.tracing import TracedUseCase
 
 
@@ -29,6 +30,10 @@ class UpdateUserPasswordUseCase(TracedUseCase):
         if not self.password_hashing_gateway.verify(command.old_password, user_password.password_hash):
             raise InvalidCredentialsException("Invalid old password")
 
-        new_password_hash = self.password_hashing_gateway.hash(command.new_password)
+        # Checked after the old password so a wrong current password still answers 401
+        # rather than leaking policy feedback first.
+        new_password = RawPassword(command.new_password)
+
+        new_password_hash = self.password_hashing_gateway.hash(new_password.value)
 
         self.user_password_repository.update_password(command.user_id, new_password_hash)

--- a/server/src/identity_access_management_context/domain/exceptions.py
+++ b/server/src/identity_access_management_context/domain/exceptions.py
@@ -53,6 +53,34 @@ class InvalidRefreshTokenException(AuthenticationDomainError):
     pass
 
 
+class PasswordPolicyViolationError(IdentityAccessManagementDomainError):
+    """Base exception for account-password policy violations.
+
+    Deliberately NOT an ``AuthenticationDomainError``: that family maps to 401 on
+    some routes, whereas a rejected new password is a bad request (400).
+    """
+
+    pass
+
+
+class PasswordTooShortError(PasswordPolicyViolationError):
+    """Raised when an account password is shorter than the policy minimum."""
+
+    def __init__(self, current_length: int, min_length: int):
+        super().__init__(
+            f"Password is too short: {current_length} characters. Minimum required: {min_length} characters"
+        )
+        self.current_length = current_length
+        self.min_length = min_length
+
+
+class CommonPasswordError(PasswordPolicyViolationError):
+    """Raised when an account password is a well-known common password."""
+
+    def __init__(self):
+        super().__init__("This password is too common. Please choose a less predictable one.")
+
+
 class AccountLockedException(AuthenticationDomainError):
     """Raised when a login is attempted against an account that is temporarily locked.
 

--- a/server/src/identity_access_management_context/domain/value_objects/__init__.py
+++ b/server/src/identity_access_management_context/domain/value_objects/__init__.py
@@ -1,4 +1,5 @@
 from .access_token import AccessToken
+from .raw_password import MIN_PASSWORD_LENGTH, RawPassword
 from .refresh_token import RefreshToken
 
-__all__ = ["AccessToken", "RefreshToken"]
+__all__ = ["AccessToken", "RawPassword", "MIN_PASSWORD_LENGTH", "RefreshToken"]

--- a/server/src/identity_access_management_context/domain/value_objects/raw_password.py
+++ b/server/src/identity_access_management_context/domain/value_objects/raw_password.py
@@ -5,57 +5,60 @@ from identity_access_management_context.domain.exceptions import (
     PasswordTooShortError,
 )
 
-MIN_PASSWORD_LENGTH = 12
+# SP 800-63B-4 §3.1.1.2: "Verifiers and CSPs SHALL require passwords that are used as
+# a single-factor authentication mechanism to be a minimum of 15 characters in
+# length." Login here is single-factor, so 15 is the floor, not the 8 allowed for a
+# password used as one factor of an MFA flow.
+MIN_PASSWORD_LENGTH = 15
 
-# Well-known passwords that survive the length rule. Anything shorter than
-# MIN_PASSWORD_LENGTH (password, 123456, admin, qwerty...) is already rejected by
-# length, so listing it here would be dead weight. Matched as a whole string after
-# normalisation, never as a substring: "SecurePassword123!" is a fine password and
-# must not be rejected just because it contains "password".
+# Passwords that survive the length rule. Anything shorter than MIN_PASSWORD_LENGTH
+# (password, 123456, motdepasse12...) is already rejected by length, so listing it
+# here would be dead weight.
+#
+# Honest scope: this list is reasoned, not measured. Public frequency rankings from
+# breach corpora exist for short passwords, but the population of real-world 15+
+# character passwords is too sparse to rank reliably, so these are extrapolated
+# patterns (runs, repeats, keyboard walks, lengthened classics) rather than a copied
+# top-N. The French entries are a judgement call for our userbase, not data. Length
+# does the real work; this list is a thin net over the residue, and it satisfies the
+# SHALL below. A blocklist that genuinely earns its keep means checking against Have
+# I Been Pwned (k-anonymity), which is a separate, bigger decision for a self-hosted
+# product that may run air-gapped.
+#
+# SP 800-63B-4 §3.1.1.2: "verifiers SHALL compare the prospective secret against a
+# blocklist that contains known commonly used, expected, or compromised passwords.
+# The entire password SHALL be subject to comparison, not substrings or words that
+# might be contained therein." Hence whole-string matching after normalisation:
+# "SecurePassword123!" is a fine password and must not be rejected for containing
+# "password".
 COMMON_PASSWORDS = frozenset(
     {
-        "password1234",
-        "password12345",
-        "password123456",
-        "passwordpassword",
-        "qwertyuiop12",
-        "qwertyuiop123",
-        "qwerty123456",
-        "123456789012",
-        "1234567890123",
-        "12345678901234",
+        # Runs and repeated characters
         "123456789012345",
         "1234567890123456",
-        "administrator",
-        "administrator1",
-        "letmein12345",
-        "letmein123456",
-        "welcome12345",
-        "welcome123456",
-        "iloveyou1234",
-        "iloveyou12345",
-        "monkey123456",
-        "abcd12345678",
-        "trustno1234567",
-        "passw0rd1234",
-        "sunshine1234",
-        "princess1234",
-        "football1234",
-        "baseball1234",
-        "superman1234",
-        "starwars1234",
-        "dragon123456",
-        "master123456",
-        "shadow123456",
-        "michael12345",
-        "jennifer1234",
-        "changeme1234",
-        "secret123456",
-        "default12345",
-        "temporary123",
-        "azertyuiop12",
-        "motdepasse12",
-        "motdepasse123",
+        "111111111111111",
+        "000000000000000",
+        "aaaaaaaaaaaaaaa",
+        # Words repeated to reach the length
+        "passwordpassword",
+        "motdepassemotdepasse",
+        "trustno1trustno1",
+        # Keyboard walks
+        "qwertyuiopasdfgh",
+        "qwertyuiopasdfghjkl",
+        "azertyuiopqsdfgh",
+        "qwertyuiop123456",
+        # Classics padded out to clear the length rule
+        "password12345678",
+        "administrator123",
+        "motdepasse12345",
+        "letmein123456789",
+        "welcome123456789",
+        "iloveyou12345678",
+        "changeme12345678",
+        "thisismypassword",
+        # Famous passphrase, in wordlists since xkcd 936
+        "correcthorsebatterystaple",
     }
 )
 
@@ -71,10 +74,13 @@ class RawPassword:
     - At least ``MIN_PASSWORD_LENGTH`` characters.
     - Must not be a well-known common password (whole-string match, normalised).
 
-    No composition rules (uppercase/digit/special) by design, following NIST
-    SP 800-63B: they push users toward predictable patterns ("Password1!") without
-    meaningfully raising entropy, while hurting usability. Length plus a
-    common-password blocklist is the stronger, better-supported combination.
+    No composition rules (uppercase/digit/special) by design. This is not a
+    preference: NIST SP 800-63B-4 §3.1.1.2 states "Verifiers and CSPs SHALL NOT
+    impose other composition rules (e.g., requiring mixtures of different character
+    types) for passwords." Such rules push users toward predictable patterns
+    ("Password1!") without meaningfully raising entropy, while hurting usability.
+    Length carries the policy; see COMMON_PASSWORDS for what the blocklist is and
+    is not worth.
 
     This policy covers *login credentials* only. Secrets stored inside the vault
     (password_management_context) are deliberately unconstrained: users must be able

--- a/server/src/identity_access_management_context/domain/value_objects/raw_password.py
+++ b/server/src/identity_access_management_context/domain/value_objects/raw_password.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass, field
+
+from identity_access_management_context.domain.exceptions import (
+    CommonPasswordError,
+    PasswordTooShortError,
+)
+
+MIN_PASSWORD_LENGTH = 12
+
+# Well-known passwords that survive the length rule. Anything shorter than
+# MIN_PASSWORD_LENGTH (password, 123456, admin, qwerty...) is already rejected by
+# length, so listing it here would be dead weight. Matched as a whole string after
+# normalisation, never as a substring: "SecurePassword123!" is a fine password and
+# must not be rejected just because it contains "password".
+COMMON_PASSWORDS = frozenset(
+    {
+        "password1234",
+        "password12345",
+        "password123456",
+        "passwordpassword",
+        "qwertyuiop12",
+        "qwertyuiop123",
+        "qwerty123456",
+        "123456789012",
+        "1234567890123",
+        "12345678901234",
+        "123456789012345",
+        "1234567890123456",
+        "administrator",
+        "administrator1",
+        "letmein12345",
+        "letmein123456",
+        "welcome12345",
+        "welcome123456",
+        "iloveyou1234",
+        "iloveyou12345",
+        "monkey123456",
+        "abcd12345678",
+        "trustno1234567",
+        "passw0rd1234",
+        "sunshine1234",
+        "princess1234",
+        "football1234",
+        "baseball1234",
+        "superman1234",
+        "starwars1234",
+        "dragon123456",
+        "master123456",
+        "shadow123456",
+        "michael12345",
+        "jennifer1234",
+        "changeme1234",
+        "secret123456",
+        "default12345",
+        "temporary123",
+        "azertyuiop12",
+        "motdepasse12",
+        "motdepasse123",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RawPassword:
+    """A plaintext account password that satisfies the IAM password policy.
+
+    Wraps the raw value only long enough to be hashed. Constructing one is the
+    validation gate: an invalid account password cannot be represented.
+
+    Domain Rules:
+    - At least ``MIN_PASSWORD_LENGTH`` characters.
+    - Must not be a well-known common password (whole-string match, normalised).
+
+    No composition rules (uppercase/digit/special) by design, following NIST
+    SP 800-63B: they push users toward predictable patterns ("Password1!") without
+    meaningfully raising entropy, while hurting usability. Length plus a
+    common-password blocklist is the stronger, better-supported combination.
+
+    This policy covers *login credentials* only. Secrets stored inside the vault
+    (password_management_context) are deliberately unconstrained: users must be able
+    to store a legacy site's weak password.
+    """
+
+    # repr=False so the secret never leaks through the generated __repr__ in logs
+    # or tracebacks.
+    value: str = field(repr=False)
+
+    def __post_init__(self) -> None:
+        if len(self.value) < MIN_PASSWORD_LENGTH:
+            raise PasswordTooShortError(len(self.value), MIN_PASSWORD_LENGTH)
+
+        if self.value.strip().casefold() in COMMON_PASSWORDS:
+            raise CommonPasswordError()
+
+    def __str__(self) -> str:
+        return "RawPassword(***)"

--- a/server/tests/e2e/conftest.py
+++ b/server/tests/e2e/conftest.py
@@ -318,7 +318,7 @@ def authenticate_sso_user(e2e_client, oidc_server, sso_user):
 def register_and_login_admin(client):
     admin_data = {
         "email": "admin@example.com",
-        "password": "admin",
+        "password": "admin-password-123",
         "display_name": "System Administrator",
     }
 
@@ -330,7 +330,7 @@ def register_and_login_admin(client):
         "/api/auth/login",
         json={
             "email": "admin@example.com",
-            "password": "admin",
+            "password": "admin-password-123",
         },
     )
     assert login_response.status_code == 200

--- a/server/tests/e2e/test_complete_authentication_workflow.py
+++ b/server/tests/e2e/test_complete_authentication_workflow.py
@@ -46,6 +46,16 @@ async def test_complete_authentication_workflow(
     print("📝 PHASE 1: COOKIE-BASED AUTHENTICATION")
     print("=" * 80)
 
+    # Step 1.0: A weak password must be rejected with 400 (not 500, not 201)
+    print("\n🚫 Step 1.0: Verifying the password policy rejects a weak password...")
+    weak_response = e2e_client.post(
+        "/api/auth/register-admin",
+        json={"email": "admin@example.com", "password": "a", "display_name": "Test Admin"},
+    )
+    assert weak_response.status_code == 400
+    assert "too short" in weak_response.json()["detail"].lower()
+    print("✅ Weak password correctly rejected (400)")
+
     # Step 1.1: Register admin user
     print("\n📝 Step 1.1: Registering admin user...")
     admin_data = {

--- a/server/tests/e2e/test_complete_user_workflow.py
+++ b/server/tests/e2e/test_complete_user_workflow.py
@@ -23,7 +23,7 @@ def test_complete_user_workflow(
     """
     Complete user management workflow covering all user features step by step.
 
-    Uses authenticated_admin_client (admin@example.com / password="admin") and
+    Uses authenticated_admin_client (admin@example.com / password="admin-password-123") and
     sso_user_factory (which brings in configured_sso + setup).
     """
 
@@ -41,7 +41,7 @@ def test_complete_user_workflow(
     # Step 1.2: Login with correct password returns expected response fields
     correct_login_response = authenticated_admin_client.post(
         "/api/auth/login",
-        json={"email": "admin@example.com", "password": "admin"},
+        json={"email": "admin@example.com", "password": "admin-password-123"},
     )
     assert correct_login_response.status_code == 200
     login_result = correct_login_response.json()
@@ -344,7 +344,7 @@ def test_complete_user_workflow(
     admin_email = admin_me_response2.json()["email"]
     admin_id = admin_me_response2.json()["id"]
 
-    old_password = "admin"
+    old_password = "admin-password-123"
     new_password = "NewSecurePassword123!"
 
     # Step 8.2: Admin updates their own password

--- a/server/tests/e2e/test_password_management_workflow.py
+++ b/server/tests/e2e/test_password_management_workflow.py
@@ -80,13 +80,13 @@ def test_complete_password_management_workflow(client_factory, setup, configured
     # Register and login admin
     admin_data = {
         "email": "admin@example.com",
-        "password": "admin",
+        "password": "admin-password-123",
         "display_name": "System Administrator",
     }
     admin_client.post("/api/auth/register-admin", json=admin_data)
     admin_client.post(
         "/api/auth/login",
-        json={"email": "admin@example.com", "password": "admin"},
+        json={"email": "admin@example.com", "password": "admin-password-123"},
     )
 
     # Login SSO user

--- a/server/tests/e2e/test_vault_workflow.py
+++ b/server/tests/e2e/test_vault_workflow.py
@@ -18,13 +18,13 @@ def test_vault_workflow(e2e_client, client_factory):
         "/api/auth/register-admin",
         json={
             "email": "admin@example.com",
-            "password": "admin",
+            "password": "admin-password-123",
             "display_name": "System Administrator",
         },
     )
     login_response = e2e_client.post(
         "/api/auth/login",
-        json={"email": "admin@example.com", "password": "admin"},
+        json={"email": "admin@example.com", "password": "admin-password-123"},
     )
     assert login_response.status_code == 200
     e2e_client.refresh_csrf_token()

--- a/server/tests/identity_access_management_context/unit/domain/test_raw_password.py
+++ b/server/tests/identity_access_management_context/unit/domain/test_raw_password.py
@@ -13,7 +13,7 @@ from identity_access_management_context.domain.value_objects import (
 
 
 class TestLengthRule:
-    @pytest.mark.parametrize("value", ["a", "short", "elevenchars"])
+    @pytest.mark.parametrize("value", ["a", "short", "elevenchars", "fourteenchars!"])
     def test_should_reject_password_below_minimum_length(self, value):
         with pytest.raises(PasswordTooShortError) as exc_info:
             RawPassword(value)
@@ -22,18 +22,24 @@ class TestLengthRule:
         assert exc_info.value.min_length == MIN_PASSWORD_LENGTH
 
     def test_should_accept_password_at_exactly_the_minimum_length(self):
-        value = "a" * MIN_PASSWORD_LENGTH
+        # Derived from the constant so this keeps testing the boundary if it moves.
+        # Not "a" * MIN_PASSWORD_LENGTH: a run of one character is itself blocklisted,
+        # which would make this assert the wrong rule.
+        value = ("Boundary" + "x" * MIN_PASSWORD_LENGTH)[:MIN_PASSWORD_LENGTH]
+        assert len(value) == MIN_PASSWORD_LENGTH
 
         assert RawPassword(value).value == value
 
 
 class TestCommonPasswordRule:
-    @pytest.mark.parametrize("value", ["password1234", "administrator", "qwertyuiop12"])
+    # Entries must be at least MIN_PASSWORD_LENGTH, otherwise the length rule fires
+    # first and these would assert the wrong exception.
+    @pytest.mark.parametrize("value", ["passwordpassword", "administrator123", "qwertyuiopasdfgh"])
     def test_should_reject_a_well_known_common_password(self, value):
         with pytest.raises(CommonPasswordError):
             RawPassword(value)
 
-    @pytest.mark.parametrize("value", ["PassWord1234", "  password1234  ", "PASSWORD1234"])
+    @pytest.mark.parametrize("value", ["PasswordPassword", "  passwordpassword  ", "PASSWORDPASSWORD"])
     def test_should_reject_common_password_regardless_of_case_or_padding(self, value):
         with pytest.raises(CommonPasswordError):
             RawPassword(value)

--- a/server/tests/identity_access_management_context/unit/domain/test_raw_password.py
+++ b/server/tests/identity_access_management_context/unit/domain/test_raw_password.py
@@ -1,0 +1,66 @@
+import pytest
+
+from identity_access_management_context.domain.exceptions import (
+    CommonPasswordError,
+    IdentityAccessManagementDomainError,
+    PasswordPolicyViolationError,
+    PasswordTooShortError,
+)
+from identity_access_management_context.domain.value_objects import (
+    MIN_PASSWORD_LENGTH,
+    RawPassword,
+)
+
+
+class TestLengthRule:
+    @pytest.mark.parametrize("value", ["a", "short", "elevenchars"])
+    def test_should_reject_password_below_minimum_length(self, value):
+        with pytest.raises(PasswordTooShortError) as exc_info:
+            RawPassword(value)
+
+        assert exc_info.value.current_length == len(value)
+        assert exc_info.value.min_length == MIN_PASSWORD_LENGTH
+
+    def test_should_accept_password_at_exactly_the_minimum_length(self):
+        value = "a" * MIN_PASSWORD_LENGTH
+
+        assert RawPassword(value).value == value
+
+
+class TestCommonPasswordRule:
+    @pytest.mark.parametrize("value", ["password1234", "administrator", "qwertyuiop12"])
+    def test_should_reject_a_well_known_common_password(self, value):
+        with pytest.raises(CommonPasswordError):
+            RawPassword(value)
+
+    @pytest.mark.parametrize("value", ["PassWord1234", "  password1234  ", "PASSWORD1234"])
+    def test_should_reject_common_password_regardless_of_case_or_padding(self, value):
+        with pytest.raises(CommonPasswordError):
+            RawPassword(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "SecurePassword123!",  # contains "password" but is not one
+            "my_plain_password",
+            "correct horse battery staple",
+        ],
+    )
+    def test_should_accept_a_password_merely_containing_a_common_word(self, value):
+        # Whole-string match, never substring: rejecting these would be a false positive.
+        assert RawPassword(value).value == value
+
+
+class TestSecrecyAndTyping:
+    def test_should_not_expose_the_secret_in_repr_or_str(self):
+        password = RawPassword("SecurePassword123!")
+
+        assert "SecurePassword123!" not in repr(password)
+        assert "SecurePassword123!" not in str(password)
+
+    def test_violations_should_be_catchable_as_the_policy_family_and_domain_error(self):
+        # Routes rely on the IdentityAccessManagementDomainError arm to answer 400.
+        with pytest.raises(PasswordPolicyViolationError):
+            RawPassword("a")
+        with pytest.raises(IdentityAccessManagementDomainError):
+            RawPassword("a")

--- a/server/tests/identity_access_management_context/unit/use_cases/test_register_admin_with_password_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_register_admin_with_password_use_case.py
@@ -52,7 +52,7 @@ def test_should_register_first_admin_with_password_and_return_user_id(
 ):
     user_id = UUID("7d742e0e-bb76-4728-83ef-8d546d7c62e5")
     email = "admin@lecoffre.com"
-    password = "secure123!"
+    password = "securepass123!"
     display_name = "Admin User"
 
     command = RegisterAdminWithPasswordCommand(id=user_id, email=email, password=password, display_name=display_name)
@@ -67,7 +67,7 @@ def test_should_register_first_admin_with_password_and_return_user_id(
     assert saved_user_password.id == user_id
     assert saved_user_password.email == email
     assert saved_user_password.display_name == display_name
-    assert saved_user_password.password_hash == b"hashed(secure123!)"
+    assert saved_user_password.password_hash == b"hashed(securepass123!)"
 
     # Verify admin was created in user repository with admin role
     saved_user = user_repository.get_by_id(user_id)
@@ -93,7 +93,7 @@ def test_should_raise_exception_when_admin_already_exists(
     command = RegisterAdminWithPasswordCommand(
         id=user_id,
         email="new@lecoffre.com",
-        password="secure123!",
+        password="securepass123!",
         display_name="New Admin",
     )
 
@@ -131,7 +131,7 @@ def test_should_delegate_admin_creation_to_user_management_context(
     display_name = "Admin User"
 
     command = RegisterAdminWithPasswordCommand(
-        id=user_id, email=email, password="password123", display_name=display_name
+        id=user_id, email=email, password="securepass123!", display_name=display_name
     )
 
     use_case.execute(command)
@@ -153,7 +153,7 @@ def test_should_publish_admin_registered_event_on_successful_registration(
     email = "admin@lecoffre.com"
 
     command = RegisterAdminWithPasswordCommand(
-        id=user_id, email=email, password="secure123!", display_name="Admin User"
+        id=user_id, email=email, password="securepass123!", display_name="Admin User"
     )
 
     use_case.execute(command)
@@ -172,7 +172,7 @@ def test_should_store_admin_registered_event_on_successful_registration(
     email = "admin@lecoffre.com"
 
     command = RegisterAdminWithPasswordCommand(
-        id=user_id, email=email, password="secure123!", display_name="Admin User"
+        id=user_id, email=email, password="securepass123!", display_name="Admin User"
     )
 
     use_case.execute(command)

--- a/server/tests/identity_access_management_context/unit/use_cases/test_register_admin_with_password_use_case.py
+++ b/server/tests/identity_access_management_context/unit/use_cases/test_register_admin_with_password_use_case.py
@@ -52,7 +52,7 @@ def test_should_register_first_admin_with_password_and_return_user_id(
 ):
     user_id = UUID("7d742e0e-bb76-4728-83ef-8d546d7c62e5")
     email = "admin@lecoffre.com"
-    password = "securepass123!"
+    password = "securepass12345!"
     display_name = "Admin User"
 
     command = RegisterAdminWithPasswordCommand(id=user_id, email=email, password=password, display_name=display_name)
@@ -67,7 +67,7 @@ def test_should_register_first_admin_with_password_and_return_user_id(
     assert saved_user_password.id == user_id
     assert saved_user_password.email == email
     assert saved_user_password.display_name == display_name
-    assert saved_user_password.password_hash == b"hashed(securepass123!)"
+    assert saved_user_password.password_hash == b"hashed(securepass12345!)"
 
     # Verify admin was created in user repository with admin role
     saved_user = user_repository.get_by_id(user_id)
@@ -93,7 +93,7 @@ def test_should_raise_exception_when_admin_already_exists(
     command = RegisterAdminWithPasswordCommand(
         id=user_id,
         email="new@lecoffre.com",
-        password="securepass123!",
+        password="securepass12345!",
         display_name="New Admin",
     )
 
@@ -131,7 +131,7 @@ def test_should_delegate_admin_creation_to_user_management_context(
     display_name = "Admin User"
 
     command = RegisterAdminWithPasswordCommand(
-        id=user_id, email=email, password="securepass123!", display_name=display_name
+        id=user_id, email=email, password="securepass12345!", display_name=display_name
     )
 
     use_case.execute(command)
@@ -153,7 +153,7 @@ def test_should_publish_admin_registered_event_on_successful_registration(
     email = "admin@lecoffre.com"
 
     command = RegisterAdminWithPasswordCommand(
-        id=user_id, email=email, password="securepass123!", display_name="Admin User"
+        id=user_id, email=email, password="securepass12345!", display_name="Admin User"
     )
 
     use_case.execute(command)
@@ -172,7 +172,7 @@ def test_should_store_admin_registered_event_on_successful_registration(
     email = "admin@lecoffre.com"
 
     command = RegisterAdminWithPasswordCommand(
-        id=user_id, email=email, password="securepass123!", display_name="Admin User"
+        id=user_id, email=email, password="securepass12345!", display_name="Admin User"
     )
 
     use_case.execute(command)


### PR DESCRIPTION
# Pull Request Title

## Description

Fixes **AUTH-VULN-08**. Account passwords had **no validation whatsoever**: a one character password was accepted at all three points that set one:
- `POST /api/auth/register-admin`
- `POST /api/users/`
- `PUT /api/users/me/password`

### What this adds

A `RawPassword` value object in the IAM domain, mirroring the existing `VaultConfiguration` precedent (frozen dataclass, validation in `__post_init__`, typed domain errors). Constructing it **is** the validation gate, so an invalid account password cannot be represented. It is built in the three use cases that set a password, and **never** in `PasswordLoginUseCase`.

**Policy:** length **>= 15** plus a **common-password blocklist**.

## Why length over complexity (a deliberate deviation from the finding)

The finding asked for "complexity". We follow **NIST SP 800-63B-4 §3.1.1.2** instead, which does not merely recommend against composition rules, it forbids them: verifiers "SHALL NOT impose other composition rules (e.g., requiring mixtures of different character types) for passwords". They push users toward predictable patterns (`Password1!`) without meaningfully raising entropy, while hurting usability.

The same section sets our length floor: passwords used as a single-factor authentication mechanism "SHALL ... be a minimum of 15 characters in length" (the 8 character floor applies only to a password used as one factor of an MFA flow). Login here is single-factor, so **we go beyond the 12 the finding asked for** on the one axis that carries the policy.

### Blocklist design

Matched on the **whole normalised string** (casefold + strip), never as a substring. This is also from §3.1.1.2: "The entire password SHALL be subject to comparison, not substrings or words that might be contained therein." A substring match would reject `SecurePassword123!`, a perfectly good password, purely because it contains "password".

The list only holds entries of 15+ characters: anything shorter is already excluded by the length rule, so listing `password` or `motdepasse12` would be dead weight. It is 21 entries covering the patterns that survive the length rule (runs, repeated words, keyboard walks, lengthened classics).

Worth being honest about its weight: the list is reasoned, not measured. Public frequency rankings from breach corpora exist for short passwords, but the 15+ population is too sparse to rank reliably, so these are extrapolated patterns rather than a copied top-N. Length does the real work here; the blocklist is a thin net over the residue and satisfies the SHALL above. A blocklist that genuinely earns its keep means checking against Have I Been Pwned (k-anonymity), a separate and bigger decision for a self-hosted product that may run air-gapped.

### Two related defects fixed along the way

- **`register-admin` returned 500, not 400.** It had no `except IdentityAccessManagementDomainError` arm, so any domain validation error fell through to the generic 500 handler. Added, in line with the other two routes.
- **`create_user` saved the User before hashing.** Validating late would have left an orphaned `User` row with no `UserPassword`. Validation now runs before the save.

### Frontend

Required for a coherent UX, otherwise the client passes and the API answers 400:
- - `StepAdminAccountForm.vue`: zod `min(6)` becomes `min(15)` (password and confirm). This is the first-admin form in the setup wizard, right after the Shamir key generation.
- `CreateUserModal.vue`: only checked presence, now also checks the minimum length.
- `LoginForm.vue` deliberately untouched: never gate login on policy.

The blocklist is intentionally **not** mirrored client side. It is a business rule and belongs in the backend domain. That is the one case where the user learns of a rejection after the round trip, which the forms already surface as a toast.

## Existing accounts are not affected

- **Login never validates the policy**, so existing users and the first admin keep signing in with their current password, however weak.
- **Changing a password** verifies the old one against its hash with no policy check, and only constrains the new one.
- **No migration**, no re-hash, no column touched.

Corollary worth stating: this stops new weak passwords, it does not remediate existing ones. Forcing a rotation for legacy accounts would be a separate piece of work.

## Checklist
- [x] I have tested the changes locally.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have ensured that my code follows the project's coding standards.


New tests:
- - `tests/identity_access_management_context/unit/domain/test_raw_password.py` (16 cases, the repo's first value-object test): length boundary, blocklist including case and padding variants, secret never leaking through `repr`/`str`, and a case pinning that `SecurePassword123!` **is accepted** (guards the whole-string decision).
- E2E: `register-admin` with `"password": "a"` returns **400** with a "too short" detail, which also pins the 500 fix above.

Test passwords were updated where they registered or changed an account (notably the `register_and_login_admin` e2e helper). Deliberately-wrong passwords in 401 and lockout assertions were left short, since login does not validate policy.