### PR TITLE
security: document is-configured as intentionally anonymous (AUTHZ-VULN-07)

### DIFF
--- a/frontend/src/client/sdk.gen.ts
+++ b/frontend/src/client/sdk.gen.ts
@@ -702,14 +702,11 @@ export const ssoCallbackAuthSsoCallbackGet = <ThrowOnError extends boolean = fal
 /**
  * Check if SSO is configured
  *
- * Check if SSO (Single Sign-On) configuration is set.
+ * Check whether SSO (Single Sign-On) has been configured.
  *
- * Returns a boolean indicating whether the system has been configured with SSO settings.
- *
- * - **Authorization**: Bearer token with admin role required
- * - **Returns**: `is_set` - True if SSO is configured, False otherwise
- *
- * **Note**: Only administrators can check SSO configuration status.
+ * Intentionally anonymous: the login page calls this before authentication to
+ * show or hide the SSO button. Returns only ``is_set``, never any provider
+ * detail.
  */
 export const isSsoConfigSetAuthSsoIsConfiguredGet = <ThrowOnError extends boolean = false>(options?: Options<IsSsoConfigSetAuthSsoIsConfiguredGetData, ThrowOnError>) => (options?.client ?? client).get<IsSsoConfigSetAuthSsoIsConfiguredGetResponses, unknown, ThrowOnError>({ url: '/auth/sso/is-configured', ...options });
 

--- a/server/src/identity_access_management_context/adapters/primary/fastapi/routes/sso/is_sso_config_set_route.py
+++ b/server/src/identity_access_management_context/adapters/primary/fastapi/routes/sso/is_sso_config_set_route.py
@@ -32,14 +32,11 @@ def is_sso_config_set(
     usecase: IsSsoConfigSetUseCase = Depends(get_is_sso_config_set_usecase),
 ):
     """
-    Check if SSO (Single Sign-On) configuration is set.
+    Check whether SSO (Single Sign-On) has been configured.
 
-    Returns a boolean indicating whether the system has been configured with SSO settings.
-
-    - **Authorization**: Bearer token with admin role required
-    - **Returns**: `is_set` - True if SSO is configured, False otherwise
-
-    **Note**: Only administrators can check SSO configuration status.
+    Intentionally anonymous: the login page calls this before authentication to
+    show or hide the SSO button. Returns only ``is_set``, never any provider
+    detail.
     """
     try:
         command = IsSsoConfigSetCommand()

--- a/server/tests/e2e/test_sso_security.py
+++ b/server/tests/e2e/test_sso_security.py
@@ -59,3 +59,22 @@ def test_sso_configure_without_auth_still_returns_401(unauthenticated_client):
     response = unauthenticated_client.post("/api/auth/sso/configure", json=_CONFIGURE_BODY)
 
     assert response.status_code == 401
+
+
+def test_is_configured_is_anonymous_and_leaks_only_the_boolean(unauthenticated_client, configured_sso):
+    # The login page calls this before the user authenticates, so the
+    # endpoint is intentionally reachable without an access_token cookie. Crucially,
+    # even with SSO configured the anonymous response is a single boolean and never
+    # the discovery URL, client ID or any IdP endpoint.
+    response = unauthenticated_client.get("/api/auth/sso/is-configured")
+
+    assert response.status_code == 200
+    assert response.json() == {"is_set": True}
+
+
+def test_is_configured_reports_false_anonymously_when_unset(unauthenticated_client):
+    # Same anonymous contract with no SSO configured: 200 and only the boolean.
+    response = unauthenticated_client.get("/api/auth/sso/is-configured")
+
+    assert response.status_code == 200
+    assert response.json() == {"is_set": False}


### PR DESCRIPTION
# Pull Request Title

## Description
<!-- Provide a brief description of the changes introduced by this pull request. -->
Addresses AUTHZ-VULN-07. The finding states that GET /api/auth/sso/is-configured returns the discovery URL, client ID and SSO status without authentication, and recommends either requiring admin auth or reducing the response to a strict boolean.

The premise does not hold for the named endpoint. It already returns only a boolean is_set, and it never returned anything else:

## Related Issues
<!-- List any related issues or tasks. Use "Fixes #<issue_number>" to automatically close the issue when the PR is merged. -->
- Fixes #

## Checklist
- [x] I have tested the changes locally.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have ensured that my code follows the project's coding standards.

## Screenshots (if applicable)
<!-- Add screenshots to help explain the changes, if applicable. -->
