### PR TITLE
ci: fail fast when a lockfile is out of sync

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,8 +40,7 @@ jobs:
 
           `bun install --frozen-lockfile` refused to install: `frontend/bun.lock` disagrees with `frontend/package.json`.
 
-              cd frontend && bun install
-              git add frontend/bun.lock
+              cd frontend && bun install && git add bun.lock
 
           On a Dependabot npm PR this is expected. Dependabot updates `package.json`
           and `package-lock.json` but never `bun.lock`, so the regeneration above is
@@ -115,10 +114,9 @@ jobs:
           tee -a "$GITHUB_STEP_SUMMARY" <<'EOF'
           ### ❌ Backend dependencies are out of sync
 
-          `uv sync --frozen` refused to install: `server/uv.lock` disagrees with `server/pyproject.toml`.
+          `uv sync --frozen --group monitoring` refused to install: `server/uv.lock` disagrees with `server/pyproject.toml`.
 
-              cd server && uv lock
-              git add server/uv.lock
+              cd server && uv lock && git add uv.lock
           EOF
           exit 1
 
@@ -244,8 +242,7 @@ jobs:
 
           `uv sync --frozen` refused to install: `server/uv.lock` disagrees with `server/pyproject.toml`.
 
-              cd server && uv lock
-              git add server/uv.lock
+              cd server && uv lock && git add uv.lock
           EOF
           exit 1
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,21 +24,43 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
+        id: install
         working-directory: frontend/
-        run: bun install --frozen-lockfile
+        run: |
+          if bun install --frozen-lockfile; then
+            exit 0
+          fi
+
+          # bun.lock is the only lockfile CI and the Dockerfile install from.
+          # package-lock.json is kept solely for GitHub's dependency graph, which
+          # does not read bun.lock, so a Dependabot npm PR bumps a direct
+          # dependency in package.json and leaves bun.lock behind.
+          tee -a "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### ❌ Frontend dependencies are out of sync
+
+          `bun install --frozen-lockfile` refused to install: `frontend/bun.lock` disagrees with `frontend/package.json`.
+
+              cd frontend && bun install
+              git add frontend/bun.lock
+
+          On a Dependabot npm PR this is expected. Dependabot updates `package.json`
+          and `package-lock.json` but never `bun.lock`, so the regeneration above is
+          a required manual step before the PR can go green.
+          EOF
+          exit 1
 
       - name: Run Linting
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: frontend/
         run: bunx eslint .
 
       - name: Check Formatting
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: frontend/
         run: bunx prettier --check src/
 
       - name: Check Dependencies Security
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: frontend/
         run: |
           bun audit --json > /tmp/bun_audit.json || true
@@ -56,7 +78,7 @@ jobs:
           node /tmp/check_bun_audit.js
 
       - name: Run Unit + Component Tests
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: frontend/
         run: bunx vitest run
 
@@ -65,7 +87,7 @@ jobs:
       # populates .tsbuildinfo and masks cold-start failures that the
       # Dockerfile's `bun run build` would hit on a clean filesystem.
       - name: Type Check + Build Project
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: frontend/
         run: bun run build
 
@@ -83,21 +105,35 @@ jobs:
           cache-dependency-glob: "server/uv.lock"
 
       - name: Install dependencies
+        id: install
         working-directory: server/
-        run: uv sync --frozen --group monitoring
+        run: |
+          if uv sync --frozen --group monitoring; then
+            exit 0
+          fi
+
+          tee -a "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### ❌ Backend dependencies are out of sync
+
+          `uv sync --frozen` refused to install: `server/uv.lock` disagrees with `server/pyproject.toml`.
+
+              cd server && uv lock
+              git add server/uv.lock
+          EOF
+          exit 1
 
       - name: Check Formatting
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: server/
         run: uv run ruff format --check .
 
       - name: Run Linting
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: server/
         run: uv run ruff check .
 
       - name: Check Alembic Migrations
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: server/
         run: |
           # First, upgrade the database to the current head
@@ -128,7 +164,7 @@ jobs:
           rm "$MIGRATION_FILE"
 
       - name: Check Dependencies Security
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: server/
         run: |
           uv export --format requirements-txt --no-hashes > /tmp/requirements.txt
@@ -178,7 +214,7 @@ jobs:
           python3 /tmp/check_pip_audit.py
 
       - name: Run Unit Tests
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: server/
         run: uv run pytest .
 
@@ -196,21 +232,35 @@ jobs:
           cache-dependency-glob: "server/uv.lock"
 
       - name: Install dependencies (without monitoring group)
+        id: install
         working-directory: server/
-        run: uv sync --frozen
+        run: |
+          if uv sync --frozen; then
+            exit 0
+          fi
+
+          tee -a "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### ❌ Backend dependencies are out of sync
+
+          `uv sync --frozen` refused to install: `server/uv.lock` disagrees with `server/pyproject.toml`.
+
+              cd server && uv lock
+              git add server/uv.lock
+          EOF
+          exit 1
 
       - name: Check Formatting
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: server/
         run: uv run ruff format --check .
 
       - name: Run Linting
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: server/
         run: uv run ruff check .
 
       - name: Run Unit Tests
-        if: success() || failure()
+        if: (success() || failure()) && steps.install.outcome == 'success'
         working-directory: server/
         run: uv run pytest .
 

--- a/.github/workflows/helm-integration.yml
+++ b/.github/workflows/helm-integration.yml
@@ -220,7 +220,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: frontend/node_modules
-          key: bun-${{ hashFiles('frontend/bun.lockb') }}
+          key: bun-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: bun-
 
       - name: Cache Playwright browsers
@@ -228,7 +228,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('frontend/bun.lockb') }}
+          key: playwright-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: playwright-
 
       - name: Install frontend dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,12 +42,30 @@ bun install
 bun run dev
 ```
 
+## Dependency updates
+
+The frontend has two lockfiles, and only one of them is ever installed from:
+
+- **`frontend/bun.lock` is the source of truth.** CI and `frontend/Dockerfile` both run `bun install --frozen-lockfile`.
+- **`frontend/package-lock.json` exists for GitHub's dependency graph only.** The graph does not read `bun.lock`, so removing `package-lock.json` would leave Dependabot alerts looking at `package.json` alone, blind to transitive vulnerabilities.
+
+Dependabot updates `package.json` and `package-lock.json`, never `bun.lock`. So when a Dependabot npm PR bumps a **direct** dependency, every frontend job fails with `lockfile had changes, but lockfile is frozen`. Regenerate the lockfile on the PR branch:
+
+```bash
+cd frontend && bun install
+git add bun.lock
+```
+
+Bumps to transitive dependencies do not touch `package.json`, so they stay green and need nothing.
+
+The backend has no such split: Dependabot's uv updates keep `server/uv.lock` in step with `pyproject.toml`. If they ever disagree, run `cd server && uv lock`.
+
 ## How to Contribute
 
-1. **Fork the Repository**  
+1. **Fork the Repository**
   Create a fork of the repository to your GitHub account.
 
-2. **Clone Your Fork**  
+2. **Clone Your Fork**
   Clone your fork to your local machine:
 
   ```bash
@@ -55,7 +73,7 @@ bun run dev
   cd le-coffre
   ```
 
-1. **Create a Branch**  
+1. **Create a Branch**
   Create a new branch for your changes:
 
   ```bash
@@ -76,7 +94,7 @@ bun run dev
   ```bash
   git push origin feat/my-feature-branch
   ```
-  
+
 1. **Create a Pull Request**
   Go to the original repository and create a pull request from your branch. Provide a clear description of your changes and why they are needed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,7 @@ The frontend has two lockfiles, and only one of them is ever installed from:
 Dependabot updates `package.json` and `package-lock.json`, never `bun.lock`. So when a Dependabot npm PR bumps a **direct** dependency, every frontend job fails with `lockfile had changes, but lockfile is frozen`. Regenerate the lockfile on the PR branch:
 
 ```bash
-cd frontend && bun install
-git add bun.lock
+cd frontend && bun install && git add bun.lock
 ```
 
 Bumps to transitive dependencies do not touch `package.json`, so they stay green and need nothing.


### PR DESCRIPTION
# Pull Request Title

## Why

Dependabot PR #343 turned four CI jobs red. The real cause was two lines at the very top
of the install step: `bun.lock` had not been updated, so `bun install --frozen-lockfile`
refused to install anything. The jobs then kept going and filled the logs with unrelated
errors (`jiti` missing, `run-p: command not found`), which buried the actual message.

The frontend has two lockfiles on purpose:

- `bun.lock` is the source of truth. CI and `frontend/Dockerfile` install from it.
- `package-lock.json` is kept only for GitHub's dependency graph, which does not read
  `bun.lock`. Dropping it would leave Dependabot alerts seeing `package.json` alone and
  blind to transitive vulnerabilities.

Dependabot only ever updates `package.json` and `package-lock.json`, so every bump of a
*direct* dependency will land with a stale `bun.lock`. This will keep happening, so the
goal is to make it obvious in seconds rather than confusing.

## What changed

**1. An install failure is now terminal for its job.** The install step gets `id: install`
and each later step is guarded by `steps.install.outcome == 'success'`. Steps still run
past each other's failures, so you still see all lint and test problems in one go, but
nothing runs once the install itself has died. Applied to `front-ci`, `back-ci` and
`back-ci-no-monitoring`; `openapi-sync-check` already behaved correctly.

The `(success() || failure()) &&` prefix is required, not decorative: GitHub applies an
implicit `success()` to any `if` that contains no status check function, which would have
stopped the quality steps at the first failure and changed existing behaviour.

**2. Both install steps print the fix when they fail**, to the log and to
`$GITHUB_STEP_SUMMARY` so it appears on the PR checks page without opening any logs.

**3. `CONTRIBUTING.md` documents why the two lockfiles coexist**, so nobody removes
`package-lock.json` later and silently loses transitive vulnerability alerts.

## Unrelated fix included

Both caches in `helm-integration.yml` were keyed on `hashFiles('frontend/bun.lockb')`.
That is the legacy binary lockfile and it does not exist in this repo, so `hashFiles`
returned an empty string and the key was the constant `bun-` / `playwright-`: the cache
never invalidated when dependencies changed, and `restore-keys` kept restoring a stale
`node_modules`. Now keyed on `bun.lock`. Happy to split this into its own PR.

## Testing

- `actionlint` clean on both workflows.
- Install scripts extracted from the YAML and run against stubbed failing and succeeding
  `bun` / `uv`: the failure path prints and exits 1, the success path is silent and exits 0.
- Success path replayed with the real `bun` in `frontend/`.

The rendered result of the fail-fast (install red, later steps skipped) can only be
observed on the first real drift in CI.


## Checklist
- [ ] I have tested the changes locally.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have ensured that my code follows the project's coding standards.
