### PR TITLE
ci(frontend): auto-regenerate bun.lock on Dependabot PRs + pin bun version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,12 @@ updates:
         update-types:
           - "minor"
 
-  # Frontend dependencies. The `npm` ecosystem covers bun too — with only
-  # `bun.lock` present in /frontend, Dependabot updates that lockfile directly.
+  # Frontend dependencies. The `npm` ecosystem is what covers bun, but in
+  # practice Dependabot bumps `package.json` here and leaves `bun.lock`
+  # untouched, which fails the `--frozen-lockfile` gate in `front-ci`. The
+  # `dependabot-lockfile.yml` workflow regenerates and pushes the lockfile on
+  # Dependabot's behalf. Note that bun is supported for version updates only —
+  # Dependabot never opens *security* update PRs for it.
   - package-ecosystem: npm
     directory: /frontend
     schedule:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: frontend/package.json
 
       - name: Install dependencies
         id: install
@@ -275,6 +277,8 @@ jobs:
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: frontend/package.json
 
       - name: Install frontend dependencies
         working-directory: frontend/

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -7,17 +7,34 @@
 # behalf. It deliberately does NOT decide whether the result is correct — it
 # pushes the lockfile and lets `front-ci` re-run and judge, so the
 # `--frozen-lockfile` check stays the single arbiter.
+#
+# Three ways in:
+#   1. automatically, on a Dependabot PR touching frontend/package.json;
+#   2. by adding the `regenerate-lockfile` label to any such PR — the only path
+#      that works before this file reaches the default branch, so it is how you
+#      smoke-test changes to this workflow;
+#   3. manually via "Run workflow" with a PR number. GitHub only offers
+#      workflow_dispatch for workflows already on the default branch, so this
+#      one is unavailable until the workflow is merged.
 name: Dependabot lockfile
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
     paths:
       - frontend/package.json
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to regenerate frontend/bun.lock on"
+        required: true
+        type: string
 
-# The PAT push retriggers front-ci; serialise per-PR so two runs can't race to
-# push conflicting lockfiles.
+# Key on the pull request rather than github.ref: a workflow_dispatch run is
+# ref-selected in the UI and would otherwise not collide with the pull_request
+# run for the same PR, letting two runs race to push conflicting lockfiles.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 permissions:
@@ -25,7 +42,10 @@ permissions:
 
 jobs:
   regenerate-lockfile:
-    if: github.actor == 'dependabot[bot]'
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.actor == 'dependabot[bot]' ||
+      contains(github.event.pull_request.labels.*.name, 'regenerate-lockfile')
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -42,19 +62,52 @@ jobs:
           fi
 
           tee -a "$GITHUB_STEP_SUMMARY" <<'EOF'
-          ### ❌ `GH_PAT` is not configured as a Dependabot secret
+          ### ❌ `GH_PAT` is not configured
 
-          Dependabot-triggered workflows cannot read Actions secrets. Add the
-          token in **Settings → Secrets and variables → Dependabot → New
-          repository secret**, named `GH_PAT`, with `Contents: read/write` on
-          this repository.
+          For Dependabot-triggered runs the token must live in the **Dependabot**
+          secret store — those workflows cannot read Actions secrets. Add it in
+          **Settings → Secrets and variables → Dependabot → New repository
+          secret**, named `GH_PAT`, with `Contents: read/write` on this
+          repository.
           EOF
           exit 1
+
+      - name: Resolve target branch
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            branch=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefName --jq .headRefName)
+          else
+            branch="$HEAD_REF"
+          fi
+
+          if [ -z "$branch" ]; then
+            echo "::error::Could not resolve a head branch to work on."
+            exit 1
+          fi
+
+          # The whole point is to fix up a pull request branch. Refusing the
+          # default branch keeps a mistyped PR number from pushing to main.
+          default_branch=$(gh repo view "$GITHUB_REPOSITORY" --json defaultBranchRef --jq .defaultBranchRef.name)
+          if [ "$branch" = "$default_branch" ]; then
+            echo "::error::Refusing to run against the default branch ($default_branch)."
+            exit 1
+          fi
+
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "Working on branch: $branch"
 
       - name: Checkout pull request branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ steps.target.outputs.branch }}
           token: ${{ secrets.GH_PAT }}
 
       - name: Install Bun
@@ -68,6 +121,8 @@ jobs:
 
       - name: Push lockfile if it changed
         run: |
+          set -euo pipefail
+
           if git diff --quiet -- frontend/bun.lock; then
             echo "bun.lock already matches package.json — nothing to do."
             exit 0
@@ -82,7 +137,7 @@ jobs:
           tee -a "$GITHUB_STEP_SUMMARY" <<'EOF'
           ### ✅ Regenerated `frontend/bun.lock`
 
-          Dependabot updated `package.json` without the lockfile. The
-          regenerated `bun.lock` has been pushed to this branch; `front-ci` will
-          re-run and validate it with `bun install --frozen-lockfile`.
+          `package.json` had moved without the lockfile. The regenerated
+          `bun.lock` has been pushed to this branch; `front-ci` will re-run and
+          validate it with `bun install --frozen-lockfile`.
           EOF

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -53,21 +53,26 @@ jobs:
       # only see *Dependabot* secrets — Actions secrets are not available. A
       # missing PAT would otherwise surface as `actions/checkout` silently
       # falling back to the read-only token and a confusing push failure.
-      - name: Verify GH_PAT is available
+      - name: Verify BUN_LOCKFILE_PAT is available
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
+          BUN_LOCKFILE_PAT: ${{ secrets.BUN_LOCKFILE_PAT }}
         run: |
-          if [ -n "$GH_PAT" ]; then
+          if [ -n "$BUN_LOCKFILE_PAT" ]; then
             exit 0
           fi
 
           tee -a "$GITHUB_STEP_SUMMARY" <<'EOF'
-          ### ❌ `GH_PAT` is not configured
+          ### ❌ `BUN_LOCKFILE_PAT` is not configured
 
-          For Dependabot-triggered runs the token must live in the **Dependabot**
-          secret store — those workflows cannot read Actions secrets. Add it in
-          **Settings → Secrets and variables → Dependabot → New repository
-          secret**, named `GH_PAT`, with `Contents: read/write` on this
+          This run resolved the secret from the store matching its trigger and
+          found nothing. The token must exist in **both** stores under
+          **Settings → Secrets and variables**:
+
+          - **Dependabot** — used when Dependabot itself opens or updates the PR
+          - **Actions** — used when a human starts the job, via the
+            `regenerate-lockfile` label or "Run workflow"
+
+          Grant it `Contents: read/write` and `Pull requests: read` on this
           repository.
           EOF
           exit 1
@@ -75,7 +80,7 @@ jobs:
       - name: Resolve target branch
         id: target
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ secrets.BUN_LOCKFILE_PAT }}
           EVENT_NAME: ${{ github.event_name }}
           PR_NUMBER: ${{ inputs.pr_number }}
           HEAD_REF: ${{ github.head_ref }}
@@ -108,7 +113,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ steps.target.outputs.branch }}
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.BUN_LOCKFILE_PAT }}
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,88 @@
+# Dependabot's npm ecosystem supports bun (GA Feb 2025, bun >= 1.1.39), but in
+# this repo it consistently emits manifest-only updates: PRs #351, #352 and #355
+# each changed `frontend/package.json` and left `bun.lock` untouched, so every
+# one of them fails the `--frozen-lockfile` gate in `front-ci`.
+#
+# This workflow closes that gap by regenerating the lockfile on Dependabot's
+# behalf. It deliberately does NOT decide whether the result is correct — it
+# pushes the lockfile and lets `front-ci` re-run and judge, so the
+# `--frozen-lockfile` check stays the single arbiter.
+name: Dependabot lockfile
+
+on:
+  pull_request:
+    paths:
+      - frontend/package.json
+
+# The PAT push retriggers front-ci; serialise per-PR so two runs can't race to
+# push conflicting lockfiles.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  regenerate-lockfile:
+    if: github.actor == 'dependabot[bot]'
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      # Workflows triggered by Dependabot get a read-only GITHUB_TOKEN and can
+      # only see *Dependabot* secrets — Actions secrets are not available. A
+      # missing PAT would otherwise surface as `actions/checkout` silently
+      # falling back to the read-only token and a confusing push failure.
+      - name: Verify GH_PAT is available
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -n "$GH_PAT" ]; then
+            exit 0
+          fi
+
+          tee -a "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### ❌ `GH_PAT` is not configured as a Dependabot secret
+
+          Dependabot-triggered workflows cannot read Actions secrets. Add the
+          token in **Settings → Secrets and variables → Dependabot → New
+          repository secret**, named `GH_PAT`, with `Contents: read/write` on
+          this repository.
+          EOF
+          exit 1
+
+      - name: Checkout pull request branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: frontend/package.json
+
+      - name: Regenerate bun.lock
+        working-directory: frontend/
+        run: bun install
+
+      - name: Push lockfile if it changed
+        run: |
+          if git diff --quiet -- frontend/bun.lock; then
+            echo "bun.lock already matches package.json — nothing to do."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add frontend/bun.lock
+          git commit -m "chore(frontend): regenerate bun.lock"
+          git push
+
+          tee -a "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### ✅ Regenerated `frontend/bun.lock`
+
+          Dependabot updated `package.json` without the lockfile. The
+          regenerated `bun.lock` has been pushed to this branch; `front-ci` will
+          re-run and validate it with `bun install --frozen-lockfile`.
+          EOF

--- a/.github/workflows/helm-integration.yml
+++ b/.github/workflows/helm-integration.yml
@@ -215,6 +215,8 @@ jobs:
       # ── Playwright E2E ────────────────────────────────────────
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: frontend/package.json
 
       - name: Cache bun dependencies
         uses: actions/cache@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,13 +44,17 @@ bun run dev
 
 ## Dependency updates
 
-**`frontend/bun.lock` is the only frontend lockfile.** CI, `frontend/Dockerfile` and Dependabot all work from it — never add a `package-lock.json` alongside it, or Dependabot will start updating that one instead and leave `bun.lock` behind.
+**`frontend/bun.lock` is the only frontend lockfile.** CI and `frontend/Dockerfile` work from it — never add a `package-lock.json` alongside it, or Dependabot will start updating that one instead and leave `bun.lock` behind.
 
 If you edit `frontend/package.json` by hand, regenerate the lockfile in the same commit, or every frontend job fails with `lockfile had changes, but lockfile is frozen`:
 
 ```bash
 cd frontend && bun install && git add bun.lock
 ```
+
+Dependabot does **not** do this for you: it bumps `frontend/package.json` and leaves the lockfile behind. The `dependabot-lockfile.yml` workflow covers that gap — on any Dependabot PR touching `frontend/package.json` it runs `bun install` and pushes the regenerated `bun.lock`, which retriggers `front-ci` to validate the result. It authenticates with a `GH_PAT` stored as a **Dependabot** secret; Dependabot-triggered workflows cannot read Actions secrets, so the two stores must both hold the token.
+
+The bun version is pinned by `packageManager` in `frontend/package.json`. `setup-bun` reads it via `bun-version-file`, and `frontend/Dockerfile` plus `Dockerfile.dev` hardcode the matching version — keep all three in step when bumping, otherwise a `bun.lock` written by one can fail `--frozen-lockfile` in another.
 
 The backend works the same way: Dependabot's uv updates keep `server/uv.lock` in step with `pyproject.toml`. If they ever disagree, run `cd server && uv lock`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,11 @@ cd frontend && bun install && git add bun.lock
 
 Dependabot does **not** do this for you: it bumps `frontend/package.json` and leaves the lockfile behind. The `dependabot-lockfile.yml` workflow covers that gap — on any Dependabot PR touching `frontend/package.json` it runs `bun install` and pushes the regenerated `bun.lock`, which retriggers `front-ci` to validate the result. It authenticates with a `GH_PAT` stored as a **Dependabot** secret; Dependabot-triggered workflows cannot read Actions secrets, so the two stores must both hold the token.
 
+You can also start it by hand on any PR whose diff touches `frontend/package.json`:
+
+- **Add the `regenerate-lockfile` label** to the PR. This is the only route that works while the workflow itself is still under review, because a `pull_request` run uses the workflow file from the PR branch.
+- **Actions → Dependabot lockfile → Run workflow**, passing a PR number. GitHub only offers `workflow_dispatch` for workflows already on the default branch, so this becomes available once the workflow is merged. It refuses to run against the default branch.
+
 The bun version is pinned by `packageManager` in `frontend/package.json`. `setup-bun` reads it via `bun-version-file`, and `frontend/Dockerfile` plus `Dockerfile.dev` hardcode the matching version — keep all three in step when bumping, otherwise a `bun.lock` written by one can fail `--frozen-lockfile` in another.
 
 The backend works the same way: Dependabot's uv updates keep `server/uv.lock` in step with `pyproject.toml`. If they ever disagree, run `cd server && uv lock`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ If you edit `frontend/package.json` by hand, regenerate the lockfile in the same
 cd frontend && bun install && git add bun.lock
 ```
 
-Dependabot does **not** do this for you: it bumps `frontend/package.json` and leaves the lockfile behind. The `dependabot-lockfile.yml` workflow covers that gap — on any Dependabot PR touching `frontend/package.json` it runs `bun install` and pushes the regenerated `bun.lock`, which retriggers `front-ci` to validate the result. It authenticates with a `GH_PAT` stored as a **Dependabot** secret; Dependabot-triggered workflows cannot read Actions secrets, so the two stores must both hold the token.
+Dependabot does **not** do this for you: it bumps `frontend/package.json` and leaves the lockfile behind. The `dependabot-lockfile.yml` workflow covers that gap — on any Dependabot PR touching `frontend/package.json` it runs `bun install` and pushes the regenerated `bun.lock`, which retriggers `front-ci` to validate the result. It authenticates with a `BUN_LOCKFILE_PAT` that must exist in **both** secret stores — Dependabot-triggered runs can only read Dependabot secrets, while human-triggered ones read Actions secrets. The token needs `Contents: read/write` and `Pull requests: read` on this repository, and nothing else; withholding `Workflows: write` means a run that somehow tried to rewrite a workflow file would be rejected at the push rather than succeed.
 
 You can also start it by hand on any PR whose diff touches `frontend/package.json`:
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -29,8 +29,11 @@ RUN groupadd -g $USER_GID $USERNAME \
     && echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
-# Install Bun globally for all users
-RUN curl -fsSL https://bun.sh/install | bash
+# Install Bun globally for all users. Keep BUN_VERSION in sync with
+# `packageManager` in frontend/package.json so the lockfile this container
+# writes is the one CI and frontend/Dockerfile can read back.
+ARG BUN_VERSION=1.3.14
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
 RUN mv /root/.bun/bin/bun /usr/local/bin/bun \
     && chmod +x /usr/local/bin/bun
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,10 @@
 # =============================================================================
 # Stage 1: Build Frontend
 # =============================================================================
-FROM oven/bun:1-alpine AS builder
+# Keep this tag in sync with `packageManager` in package.json — a bun.lock
+# written by a different bun than the one reading it here can fail the
+# --frozen-lockfile install below.
+FROM oven/bun:1.3.14-alpine AS builder
 
 WORKDIR /frontend
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "packageManager": "bun@1.3.14",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },


### PR DESCRIPTION
## Problem

Dependabot's `npm` ecosystem supports bun for version updates, but in this repo it emits **manifest-only** bumps. All three currently-open frontend PRs prove it — each was cut minutes after `main` went bun-only, and each changed `frontend/package.json` with **no lockfile at all**:

| PR | Created (UTC) | Files touched |
|---|---|---|
| #350 (`1d5a194b`) | 13:44 | `package-lock.json`, `package.json` |
| **#351** | **15:07** | **`package.json` only** |
| **#352** | **15:07** | **`package.json` only** |
| **#355** | **15:10** | **`package.json` only** |

So every one of them fails `front-ci` with `lockfile had changes, but lockfile is frozen`, and will keep doing so.

## Changes

**1. Pin bun to a single source of truth.** The version was decided independently in four floating places (`setup-bun@v2` x3 -> `latest`, `oven/bun:1-alpine`, an unpinned `curl | bash` in `Dockerfile.dev`). `frontend/package.json` now carries `"packageManager": "bun@1.3.14"`; `setup-bun` reads it via `bun-version-file`, and both Dockerfiles hardcode the match since they cannot read it at `FROM` time. This matters because `bun.lock` already carries `"configVersion": 1`, a Bun 1.3 field — a mismatch is the likely mechanism behind the manifest-only updates.

**2. New `dependabot-lockfile.yml`.** Runs `bun install` and pushes the regenerated `bun.lock`. It deliberately does **not** judge the result — the push retriggers `front-ci`, keeping `--frozen-lockfile` the single arbiter of correctness. Human PRs are untouched by default and still fail loudly. Three ways in:

| How it starts | Actor | Reads secret from |
|---|---|---|
| Dependabot opens/updates a PR touching `frontend/package.json` | `dependabot[bot]` | **Dependabot** store |
| `regenerate-lockfile` label added to any such PR | human | **Actions** store |
| Actions -> Run workflow, with a PR number | human | **Actions** store |

The label is the only route that works *before* this file reaches the default branch — a `pull_request` run executes the workflow from the PR branch, whereas GitHub only exposes `workflow_dispatch` for workflows already on `main`. So the label is how this workflow gets smoke-tested on itself. `workflow_dispatch` resolves the PR's head branch and refuses to run against the default branch.

**3. Docs.** Corrects the `dependabot.yml` comment claiming Dependabot updates `bun.lock` directly, and documents the above in `CONTRIBUTING.md`.

## Required before this works

Create a fine-grained PAT with resource owner `soma-smart`, repository `le-coffre`:

- **Contents: Read and write** — clone, and push the lockfile commit
- **Pull requests: Read** — resolve the head branch on `workflow_dispatch`
- nothing else. Withholding **Workflows: write** is deliberate: the heal commit only ever stages `frontend/bun.lock`, so a run that somehow tried to rewrite a workflow file gets rejected at the push instead of succeeding quietly.

Add it as `BUN_LOCKFILE_PAT` under **Settings -> Secrets and variables**, in **both** the **Dependabot** and **Actions** stores — which one a run reads depends on its trigger, per the table above. Note that a human labelling a *Dependabot* PR is still an Actions-secrets run.

The workflow's first step fails with these instructions rather than no-opping if the secret is missing.

## Known gap (not addressed)

Dependabot supports bun for **version updates only**; security updates are still unsupported, so frontend CVEs will never auto-open a PR. The existing `bun audit` gate in `front-ci` remains the compensating control, as already documented in `CONTRIBUTING.md`.

## Verification

`front-ci`, `openapi-sync-check`, `back-ci` and `back-ci-no-monitoring` all pass on this branch. `setup-bun` logged `Obtained version 1.3.14 from frontend/package.json` at both call sites, and `bun install --frozen-lockfile` succeeded, leaving `bun.lock` byte-identical. The `Dependabot lockfile` workflow was picked up from this branch and correctly skipped (not Dependabot, no label), confirming GitHub accepts it and that the label route will work pre-merge.

After merge, `@dependabot rebase` on #351/#352/#355 — re-running their failed checks replays the old workflow file and will not pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
