### PR TITLE
ci(deps): batch Dependabot on a weekly slot and add a 3-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
 version: 2
+
+# All ecosystems check Monday 06:00 so the week's PRs land as one batch.
+# `cooldown` covers version updates only — security PRs bypass it.
 updates:
   # Python/uv dependencies (server)
   - package-ecosystem: uv
     directory: /server
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+      day: monday
+      time: "06:00"
+      timezone: Europe/Paris
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 3
     labels:
       - dependencies
       - python:uv
@@ -37,7 +45,12 @@ updates:
     directory: /frontend
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+      day: monday
+      time: "06:00"
+      timezone: Europe/Paris
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 4
     labels:
       - dependencies
       - npm
@@ -71,7 +84,12 @@ updates:
     directory: /.github/workflows
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
+      day: monday
+      time: "06:00"
+      timezone: Europe/Paris
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 2
     labels:
       - dependencies
       - github-actions
@@ -91,7 +109,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+      day: monday
+      time: "06:00"
+      timezone: Europe/Paris
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 3
     labels:
       - dependencies
       - docker


### PR DESCRIPTION
## Summary

Dependency PRs currently arrive at random times across the week, one ecosystem at a time. This pins all four to a single weekly slot and holds back brand-new releases.

- **Schedule** — every ecosystem now checks `monday 06:00 Europe/Paris`. The interval was already `weekly`, but with no `day`/`time` Dependabot picked a random time per entry, so PRs trickled in separately.
- **Cooldown** — `default-days: 3` everywhere. This is a supply-chain measure: hijacked-maintainer attacks ship as ordinary patch/minor bumps and are typically yanked within 24-72h, so not being first to install a release removes most of that exposure.
- **PR limits** — trimmed to each entry's group count plus one slot of headroom for updates that fall outside a semver group (e.g. `update fastapi[standard] requirement from >=x`).

| Entry | Limit | Groups → realistic max |
|---|---|---|
| uv `/server` | 5 → **3** | 2 |
| npm `/frontend` | 5 → **4** | 3 |
| github-actions | 3 → **2** | 1 |
| docker `/` | 5 → **3** | 2 |

Ceiling across all entries drops from 18 to 12.

## Notes

**None of this throttles security updates.** Dependabot alert-driven PRs bypass the schedule, the cooldown ([documented](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference): cooldown is "only available for *version* updates, not *security* updates") and `open-pull-requests-limit`. That is the intended behaviour — GHSA-g6cj-pr64-35w5 landed as a major `cryptography` bump 65 seconds after the alert opened, despite the `semver-major` ignore rule, and should keep doing so.

Cooldown is set with `default-days` only. The `semver-*-days` keys are unsupported for `github-actions` and `docker`, and with a weekly schedule a longer per-tier value quantizes badly: at 5 days a minor release slips to the following Monday 4 times out of 7, and at 7 days almost everything does, turning the cadence fortnightly.

`dependabot-lockfile.yml` is unaffected — it triggers on the PR, not the schedule.

## Test plan

- [x] `.github/dependabot.yml` parses as valid YAML; schedule, cooldown and limit verified per entry
- [ ] Confirm on GitHub that the config validates (Insights → Dependency graph → Dependabot shows no config error)
- [ ] Observe the next Monday run to confirm PRs batch as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)