### PR TITLE
test(e2e)+feat(iam): cover the CLI SSO flow and discriminate the state-check failure

### DIFF
--- a/server/src/identity_access_management_context/adapters/primary/fastapi/routes/sso/sso_callback_route.py
+++ b/server/src/identity_access_management_context/adapters/primary/fastapi/routes/sso/sso_callback_route.py
@@ -31,6 +31,17 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/auth", tags=["Authentication"])
 
 
+def _state_rejection_reason(state: str | None, expected_state: str | None) -> str | None:
+    """Why the CSRF state check failed, or None when it passed."""
+    if not state:
+        return "state query parameter missing"
+    if not expected_state:
+        return "sso_state cookie missing — the client must reuse one cookie jar across /auth/sso/url and this callback"
+    if not secrets.compare_digest(state, expected_state):
+        return "state mismatch"
+    return None
+
+
 class SsoUserInfo(BaseModel):
     user_id: UUID
     email: str
@@ -71,7 +82,11 @@ async def sso_callback(
     Returns user information and sets HTTP-only secure cookies with JWT tokens.
     """
     expected_state = request.cookies.get(SSO_STATE_COOKIE)
-    if not state or not expected_state or not secrets.compare_digest(state, expected_state):
+    rejection_reason = _state_rejection_reason(state, expected_state)
+    if rejection_reason:
+        # The body stays generic so a forged state learns nothing. The reason goes
+        # to the log only, and never carries the state itself — it is a CSRF token.
+        logger.warning("Rejecting SSO callback: %s", rejection_reason)
         response.delete_cookie(SSO_STATE_COOKIE)
         raise HTTPException(status_code=400, detail="Invalid SSO state")
     response.delete_cookie(SSO_STATE_COOKIE)

--- a/server/tests/e2e/test_complete_authentication_workflow.py
+++ b/server/tests/e2e/test_complete_authentication_workflow.py
@@ -9,10 +9,11 @@ This test covers the entire authentication system in one comprehensive workflow:
 5. SSO authentication flow (configuration, URL, callback)
 6. Refresh token workflow
 7. Token validation with protected endpoints
+8. CLI SSO flow (redirect_uri override on the callback)
 """
 
 import time
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import httpx
 import pytest
@@ -647,6 +648,98 @@ async def test_complete_authentication_workflow(
     print("✅ Lockout released after window elapsed — correct password succeeds end-to-end")
 
     # =========================================================================
+    # PHASE 8: CLI SSO FLOW (redirect_uri override)
+    # =========================================================================
+    print("\n" + "=" * 80)
+    print("💻 PHASE 8: CLI SSO FLOW (redirect_uri override)")
+    print("=" * 80)
+
+    # A CLI (no browser) drives the same two endpoints as the SPA, with two
+    # differences: it listens on a loopback port instead of APP_BASE_URL, and it
+    # therefore passes that URI back as ?redirect_uri= so the token exchange uses
+    # the same value the IdP saw. `/auth/sso/url` binds the CSRF state to an
+    # httpOnly `sso_state` cookie, so the CLI MUST reuse one cookie jar across
+    # both calls. Only the integration tier covered this override before, which is
+    # why the state check could land without turning anything red.
+    cli_redirect_uri = "http://127.0.0.1:9876/callback"
+
+    # Step 8.1: the CLI asks for the authorization URL on its own cookie jar
+    print("\n🔗 Step 8.1: CLI requests the SSO authorization URL...")
+    cli_client = client_factory()
+    cli_url_response = cli_client.get("/api/auth/sso/url")
+    assert cli_url_response.status_code == 200
+    cli_sso_url = cli_url_response.json()
+    assert isinstance(cli_sso_url, str)
+    assert cli_client.cookies.get("sso_state"), "the CLI's jar must hold the sso_state cookie"
+
+    # The CLI swaps in its loopback listener; the state (and its cookie) is untouched.
+    parsed_authorize = urlparse(cli_sso_url)
+    authorize_params = parse_qs(parsed_authorize.query)
+    cli_state = authorize_params.get("state", [None])[0]
+    assert cli_state, "SSO authorization URL should carry a state parameter"
+    authorize_params["redirect_uri"] = [cli_redirect_uri]
+    cli_authorize_url = urlunparse(parsed_authorize._replace(query=urlencode(authorize_params, doseq=True)))
+    print(f"✅ Authorization URL rewritten to the CLI listener: {cli_redirect_uri}")
+
+    # Step 8.2: the user authorizes; the IdP redirects to the loopback listener
+    print("\n🔐 Step 8.2: Simulating user authorization against the loopback listener...")
+    cli_auth_response = httpx.post(
+        cli_authorize_url,
+        data={"sub": oidc_test_user["sub"]},
+        follow_redirects=False,
+    )
+    assert cli_auth_response.status_code in [302, 303]
+    cli_callback_url = cli_auth_response.headers.get("location")
+    assert cli_callback_url
+    assert cli_callback_url.startswith(cli_redirect_uri), (
+        f"IdP should redirect to the CLI listener, got {cli_callback_url}"
+    )
+    cli_query = parse_qs(urlparse(cli_callback_url).query)
+    cli_code = cli_query.get("code", [None])[0]
+    assert cli_code
+    print(f"✅ Authorization code captured on the loopback listener: {cli_code[:10]}...")
+
+    # Step 8.3: same jar → the state check passes and the override drives the exchange
+    print("\n✨ Step 8.3: CLI completes the callback with its redirect_uri override...")
+    cli_callback_response = cli_client.get(
+        "/api/auth/sso/callback?" + urlencode({"code": cli_code, "state": cli_state, "redirect_uri": cli_redirect_uri})
+    )
+    assert cli_callback_response.status_code == 200, (
+        f"CLI callback failed: status={cli_callback_response.status_code} body={cli_callback_response.json()!r}"
+    )
+    assert cli_callback_response.json()["user"]["email"] == oidc_test_user["email"]
+    assert cli_callback_response.cookies.get("access_token") is not None
+    assert cli_callback_response.cookies.get("refresh_token") is not None
+    print("✅ CLI SSO login succeeded with the redirect_uri override")
+
+    # Step 8.4: the token is a real session, not just a 200
+    print("\n👤 Step 8.4: Validating the CLI session against /users/me...")
+    cli_me_response = cli_client.get("/api/users/me")
+    assert cli_me_response.status_code == 200
+    assert cli_me_response.json()["email"] == oidc_test_user["email"]
+    print("✅ CLI session accepted by a protected endpoint")
+
+    # Step 8.5: the regression this phase exists for. A CLI that opens a fresh HTTP
+    # client per call never sends `sso_state` back, so the callback is rejected
+    # before the code is ever exchanged — the state check runs first, so the code
+    # value is irrelevant here.
+    print("\n🚫 Step 8.5: A CLI that drops the cookie jar between calls must be rejected...")
+    jar_a = client_factory()
+    stateless_url_response = jar_a.get("/api/auth/sso/url")
+    assert stateless_url_response.status_code == 200
+    orphan_state = parse_qs(urlparse(stateless_url_response.json()).query).get("state", [None])[0]
+    assert orphan_state
+
+    jar_b = client_factory()  # second client: holds no sso_state cookie
+    orphan_response = jar_b.get(
+        "/api/auth/sso/callback?"
+        + urlencode({"code": "unused-code", "state": orphan_state, "redirect_uri": cli_redirect_uri})
+    )
+    assert orphan_response.status_code == 400
+    assert orphan_response.json()["detail"] == "Invalid SSO state"
+    print("✅ Split cookie jar correctly rejected (400 Invalid SSO state)")
+
+    # =========================================================================
     # FINAL VALIDATION
     # =========================================================================
     print("\n" + "=" * 80)
@@ -659,6 +752,7 @@ async def test_complete_authentication_workflow(
     print("✅ Phase 5: SSO authentication")
     print("✅ Phase 6: Refresh token workflow")
     print("✅ Phase 7: Account lockout")
+    print("✅ Phase 8: CLI SSO flow (redirect_uri override)")
     print("\n" + "=" * 80)
     print("🎊 COMPLETE AUTHENTICATION WORKFLOW TEST PASSED!")
     print("=" * 80 + "\n")

--- a/server/tests/e2e/test_sso_security.py
+++ b/server/tests/e2e/test_sso_security.py
@@ -1,3 +1,4 @@
+import logging
 from urllib.parse import parse_qs, urlparse
 
 
@@ -78,3 +79,54 @@ def test_is_configured_reports_false_anonymously_when_unset(unauthenticated_clie
 
     assert response.status_code == 200
     assert response.json() == {"is_set": False}
+
+
+# The 400 body is deliberately generic in every rejection case, so an operator
+# reading it cannot tell a client that dropped its cookie jar (the CLI failure
+# mode) from a genuine forged state. Discriminate in the server log instead —
+# never in the response, and never by echoing the state itself, which is a CSRF
+# token.
+_SSO_CALLBACK_LOGGER = "identity_access_management_context.adapters.primary.fastapi.routes.sso.sso_callback_route"
+
+
+def test_given_no_state_cookie_when_calling_callback_should_log_the_missing_cookie_reason(
+    e2e_client, configured_sso, caplog
+):
+    url_response = e2e_client.get("/api/auth/sso/url")
+    state = parse_qs(urlparse(_extract_sso_url(url_response)).query)["state"][0]
+    e2e_client.cookies.delete("sso_state")  # the client did not keep the jar
+
+    with caplog.at_level(logging.WARNING, logger=_SSO_CALLBACK_LOGGER):
+        response = e2e_client.get(f"/api/auth/sso/callback?code=anything&state={state}")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid SSO state"
+    assert "sso_state cookie missing" in caplog.text
+    assert state not in caplog.text, "the state is a CSRF token and must never be logged"
+
+
+def test_given_mismatched_state_when_calling_callback_should_log_the_mismatch_reason(
+    e2e_client, configured_sso, caplog
+):
+    e2e_client.get("/api/auth/sso/url")  # sets the sso_state cookie
+
+    with caplog.at_level(logging.WARNING, logger=_SSO_CALLBACK_LOGGER):
+        response = e2e_client.get("/api/auth/sso/callback?code=anything&state=forged-state")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid SSO state"
+    assert "state mismatch" in caplog.text
+    assert "forged-state" not in caplog.text
+
+
+def test_given_no_state_parameter_when_calling_callback_should_log_the_missing_parameter_reason(
+    e2e_client, configured_sso, caplog
+):
+    e2e_client.get("/api/auth/sso/url")  # sets the sso_state cookie
+
+    with caplog.at_level(logging.WARNING, logger=_SSO_CALLBACK_LOGGER):
+        response = e2e_client.get("/api/auth/sso/callback?code=anything")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid SSO state"
+    assert "state query parameter missing" in caplog.text


### PR DESCRIPTION
## Context

A CLI that pulls credentials out of Le Coffre started failing with `400 Invalid SSO state` on every command. The fix belongs in that CLI (it opened a fresh `httpx` client per call, so the httpOnly `sso_state` cookie issued by `/auth/sso/url` never came back on the callback). But two gaps on our side let it happen and made it hard to place, and this PR closes both.

`dcb0f773` added `?redirect_uri=` to `/auth/sso/callback` explicitly *for CLI auth*. `18d12559` later made the CSRF `state` mandatory and bound it to a cookie. Nothing turned red, because the CLI-shaped flow was never tested over HTTP.

## What this changes

**1. `test(e2e)`: PHASE 8 in `test_complete_authentication_workflow.py`**

`redirect_uri` was covered at the unit tier (`test_sso_login_use_case.py:510`) and the integration tier (`test_sso_oidc_integration.py:364`) — both call the use case and the gateway directly and never touch the route. The new phase drives the flow the way a CLI does: fetch the authorization URL on its own cookie jar, swap the `redirect_uri` for a loopback listener, capture the code there, complete the callback with the override, then confirm the session on `/users/me`. Step 8.5 pins the reported failure mode — a client with a split cookie jar is rejected before the code is ever exchanged.

Verified mordant by mutation: forcing `redirect_uri=None` in the route fails the phase with `invalid_grant: Invalid 'redirect_uri' in request`.

**2. `feat(iam)`: discriminate the state-check failure in the log**

`400 Invalid SSO state` covered three distinct cases: no `state` parameter, no `sso_state` cookie, and a real mismatch. The response body stays generic — a forged state must learn nothing — but the reason now goes to the server log, so a missing cookie is distinguishable from an attack. The state value itself is never logged; it is a CSRF token.

## Honest scoping note

PHASE 8 would **not** have caught `18d12559` on its own: it drives the flow with one shared cookie jar, which is what a correct CLI does, so it would have stayed green. What it actually buys is a pinned `redirect_uri` contract at the HTTP tier and an executable statement of the cookie-jar requirement, which is what the next non-browser integrator needs.

Two things I deliberately left out of this PR, both worth a follow-up:

- **The cookie-jar requirement is still undocumented in the OpenAPI description** of `/auth/sso/url` and `/auth/sso/callback`. Route docstrings and `Query` descriptions land in `frontend/src/client/`, so adding them forces a client regeneration — a different footprint than this PR.
- **`SSO_STATE_MAX_AGE_SECONDS = 600` is hardcoded and undocumented.** It is the real ceiling on a slow MFA login: a CLI that raises its local wait past 10 minutes will hit a fresh `400` that looks like a regression. Worth making configurable, or at least surfacing.

## Verification

```
uv run pytest tests/ -q
759 passed, 3 skipped
```
(756 before; +1 phase in the existing workflow test, +3 logging tests)

`uv run ruff format` / `uv run ruff check src/ tests/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)