### PR TITLE
ci: run on pull requests whose base is not main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  # No base-branch filter: a stacked PR targets its parent PR's branch, not
-  # main, and would otherwise get no CI at all until the parent merges.
   pull_request:
 
 concurrency:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
+  # No base-branch filter: a stacked PR targets its parent PR's branch, not
+  # main, and would otherwise get no CI at all until the parent merges.
   pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/helm-integration.yml
+++ b/.github/workflows/helm-integration.yml
@@ -2,7 +2,6 @@ name: Helm Integration Test
 
 on:
   workflow_dispatch:
-  # See CI.yml: no base-branch filter, so stacked PRs are covered too.
   pull_request:
 
 concurrency:

--- a/.github/workflows/helm-integration.yml
+++ b/.github/workflows/helm-integration.yml
@@ -2,9 +2,8 @@ name: Helm Integration Test
 
 on:
   workflow_dispatch:
+  # See CI.yml: no base-branch filter, so stacked PRs are covered too.
   pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problem

`CI.yml` and `helm-integration.yml` both declared:

```yaml
pull_request:
  branches:
    - main
```

A stacked PR targets its parent PR's branch, not `main`, so it matches nothing. Observed on the current stack:

| PR | Base | Checks |
|---|---|---|
| #379 | `main` | 8, all green |
| #380 | `fix/sso-cli-flow-coverage` | `labeler` only |

## Why it matters less than it looks — and still matters

Nothing untested reaches `main`. Merging a stacked PR pushes commits onto the parent's head branch, which fires `synchronize` and re-runs the parent's full CI on the combined result.

The cost is *when* you learn. You review and merge the stacked PR blind, and a failure surfaces afterwards on a PR that was green, with the two changes now mixed together — which is precisely the separation stacking exists to buy.

(`main` is unprotected, so no required check blocks any of this today. This is discipline, not a gate.)

## Change

Drop the base filter on `pull_request`; keep it on `push` so a branch push doesn't double-run alongside its own PR.

Volume barely moves — every Dependabot PR already targets `main` and already runs. The only additions are stacked PRs, i.e. the ones currently uncovered. `concurrency` with `cancel-in-progress: true` is already configured, and for a `pull_request` event `github.ref` is `refs/pull/<n>/merge`, so stacked PRs don't cancel each other.

`helm-integration` is widened too. It's the heavier job, so this one is a judgement call — the alternative is leaving it on `workflow_dispatch` for stacked PRs, which means a stacked PR touching `helm/` is silently skipped unless somebody remembers. Say the word and I'll drop that half.

## Rollout

This does not retroactively help #380 — a `pull_request` run resolves its workflow from the PR's merge commit, so #380 picks the new triggers up once its branch carries this change. After merging here: rebase #379 onto `main`, then rebase #380 onto `fix/sso-cli-flow-coverage`, and #380 gets the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)